### PR TITLE
fix: comprehensive review — dead import, clustering tab, cancel mechanism

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -3,7 +3,7 @@ from analysis.pca import run_pca as run_pca, PCAResult as PCAResult
 from analysis.plsda import run_plsda as run_plsda, PLSDAResult as PLSDAResult
 from analysis.univariate import volcano_analysis as volcano_analysis, VolcanoResult as VolcanoResult
 from analysis.anova import run_anova as run_anova, ANOVAResult as ANOVAResult
-from analysis.clustering import compute_linkage as compute_linkage, select_top_features as select_top_features
+from analysis.clustering import compute_linkage as compute_linkage, select_top_features as select_top_features, run_clustering as run_clustering, ClusteringResult as ClusteringResult
 from analysis.correlation import run_correlation as run_correlation, CorrelationResult as CorrelationResult
 from analysis.roc import run_roc_analysis as run_roc_analysis, ROCResult as ROCResult
 from analysis.outlier import run_outlier_detection as run_outlier_detection, OutlierResult as OutlierResult

--- a/analysis/clustering.py
+++ b/analysis/clustering.py
@@ -1,12 +1,16 @@
 """
-階層式分群模組 — 用於 Heatmap 的 dendrogram 計算
+階層式分群模組 — 用於 Heatmap / Dendrogram 計算
 
 對應 R: hclust() + pheatmap::pheatmap()
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
-from scipy.cluster.hierarchy import linkage
+from scipy.cluster.hierarchy import cophenet, fcluster, linkage
 from scipy.spatial.distance import pdist
 
 
@@ -55,3 +59,85 @@ def select_top_features(df: pd.DataFrame, max_features: int = 2000,
 
     top_cols = scores.nlargest(max_features).index
     return df[top_cols]
+
+
+@dataclass
+class ClusteringResult:
+    """Hierarchical clustering result container."""
+
+    row_linkage: np.ndarray
+    col_linkage: np.ndarray
+    data: pd.DataFrame
+    labels: pd.Series | np.ndarray
+    method: str
+    metric: str
+    n_clusters: int
+    row_clusters: np.ndarray
+    cophenetic_corr: float
+    sample_names: list[str]
+    feature_names: list[str]
+
+
+def run_clustering(
+    data: pd.DataFrame,
+    labels,
+    method: str = "ward",
+    metric: str = "euclidean",
+    max_features: int = 2000,
+    n_clusters: int | None = None,
+) -> ClusteringResult:
+    """
+    Run hierarchical clustering on both samples and features.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Preprocessed data matrix (samples x features).
+    labels : array-like
+        Group labels aligned to rows of ``data``.
+    method : str, default="ward"
+        Linkage method: ward, complete, average, single.
+    metric : str, default="euclidean"
+        Distance metric: euclidean, correlation, cosine, etc.
+    max_features : int, default=2000
+        Maximum number of features to cluster.
+    n_clusters : int or None, default=None
+        Number of clusters for fcluster. Defaults to the number of unique labels.
+
+    Returns
+    -------
+    ClusteringResult
+    """
+    labels_arr = labels.values if hasattr(labels, "values") else np.asarray(labels)
+    if n_clusters is None:
+        n_clusters = len(set(labels_arr))
+
+    plot_df = select_top_features(data, max_features=max_features)
+
+    # Row clustering (samples)
+    row_Z = compute_linkage(plot_df.values, method=method, metric=metric)
+    row_clusters = fcluster(row_Z, t=n_clusters, criterion="maxclust")
+
+    # Cophenetic correlation for quality assessment
+    if method == "ward":
+        dist_vec = pdist(plot_df.values, metric="euclidean")
+    else:
+        dist_vec = pdist(plot_df.values, metric=metric)
+    coph_corr, _ = cophenet(row_Z, dist_vec)
+
+    # Column clustering (features)
+    col_Z = compute_linkage(plot_df.values.T, method=method, metric=metric)
+
+    return ClusteringResult(
+        row_linkage=row_Z,
+        col_linkage=col_Z,
+        data=plot_df,
+        labels=labels_arr,
+        method=method,
+        metric=metric,
+        n_clusters=n_clusters,
+        row_clusters=row_clusters,
+        cophenetic_corr=coph_corr,
+        sample_names=list(plot_df.index),
+        feature_names=list(plot_df.columns),
+    )

--- a/analysis/clustering.py
+++ b/analysis/clustering.py
@@ -108,9 +108,14 @@ def run_clustering(
     -------
     ClusteringResult
     """
+    if data.shape[0] < 2:
+        raise ValueError("At least 2 samples are required for clustering.")
+    if data.shape[1] < 2:
+        raise ValueError("At least 2 features are required for clustering.")
+
     labels_arr = labels.values if hasattr(labels, "values") else np.asarray(labels)
     if n_clusters is None:
-        n_clusters = len(set(labels_arr))
+        n_clusters = max(len(set(labels_arr)), 2)
 
     plot_df = select_top_features(data, max_features=max_features)
 

--- a/claude.md
+++ b/claude.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Build a **desktop Python GUI application** (PyQt6) that fully replicates MetaboAnalyst 6.0's standardization pipeline and statistical visualization. The goal is to open the "black box" — every algorithm must be transparent and documented.
+Build a **desktop Python GUI application** (PySide6) that fully replicates MetaboAnalyst 6.0's standardization pipeline and statistical visualization. The goal is to open the "black box" — every algorithm must be transparent and documented.
 
 **Source of truth:** `xia-lab/MetaboAnalystR` GitHub repo (`general_proc_utils.R`, `general_norm_utils.R`, `stats_univariates.R`, `stats_chemometrics.R`)
 
@@ -13,13 +13,13 @@ Build a **desktop Python GUI application** (PyQt6) that fully replicates MetaboA
 ## Tech Stack
 
 - **Language:** Python 3.10+
-- **GUI:** PyQt6 (with matplotlib embedded via `FigureCanvasQTAgg`)
+- **GUI:** PySide6 (with matplotlib embedded via `FigureCanvasQTAgg`)
 - **Core:** numpy, pandas, scipy, scikit-learn, statsmodels
 - **Visualization:** matplotlib, seaborn, plotly (3D PCA only), adjustText
 - **Specialized:** qnorm (quantile normalization), pyopls (OPLS-DA), fancyimpute (SVD impute), pyppca (PPCA impute)
 
 ```bash
-pip install numpy pandas scipy scikit-learn statsmodels matplotlib seaborn plotly adjustText PyQt6 pyqtgraph fancyimpute pyppca qnorm pyopls
+pip install numpy pandas scipy scikit-learn statsmodels matplotlib seaborn plotly adjustText PySide6 fancyimpute pyppca qnorm pyopls
 ```
 
 ---
@@ -33,7 +33,7 @@ pip install numpy pandas scipy scikit-learn statsmodels matplotlib seaborn plotl
 | [`03-gui.md`](docs/specs/03-gui.md) | GUI layout, tab descriptions, theming, widgets, threading, undo/redo |
 | [`04-i18n.md`](docs/specs/04-i18n.md) | Internationalization: Qt translation system, CJK fonts, translation table |
 | [`05-deployment.md`](docs/specs/05-deployment.md) | PyInstaller, Inno Setup, macOS signing, GitHub Actions CI/CD |
-| [`06-compatibility.md`](docs/specs/06-compatibility.md) | PyQt6 6.6+ breaking changes, style conventions, testing strategy |
+| [`06-compatibility.md`](docs/specs/06-compatibility.md) | PySide6 6.6+ breaking changes, style conventions, testing strategy |
 
 ---
 
@@ -81,7 +81,7 @@ metaboanalyst_clone/
 ├── visualization/             # Returns matplotlib Figure objects
 │   ├── pca_plot.py, volcano_plot.py, heatmap.py
 │   ├── vip_plot.py, boxplot.py, density_plot.py
-├── gui/                       # PyQt6 GUI layer
+├── gui/                       # PySide6 GUI layer
 │   ├── main_window.py, data_import_tab.py, missing_value_tab.py
 │   ├── filter_tab.py, norm_tab.py, stats_tab.py, visual_tab.py
 │   └── widgets/ (mpl_canvas.py, plotly_widget.py)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -36,6 +36,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QPlainTextEdit,
     QProgressBar,
+    QPushButton,
     QComboBox,
     QSplitter,
     QStackedWidget,
@@ -423,6 +424,12 @@ class MainWindow(QMainWindow):
         self.status_bar = QStatusBar()
         self.setStatusBar(self.status_bar)
 
+        self.cancel_button = QPushButton(self.tr("Cancel"))
+        self.cancel_button.setMaximumWidth(80)
+        self.cancel_button.setVisible(False)
+        self.cancel_button.clicked.connect(self._on_cancel_clicked)
+        self.status_bar.addPermanentWidget(self.cancel_button)
+
         self.progress_bar = QProgressBar()
         self.progress_bar.setMaximumWidth(240)
         self.progress_bar.setVisible(False)
@@ -762,6 +769,7 @@ class MainWindow(QMainWindow):
 
     def show_progress(self, visible: bool = True):
         self.progress_bar.setVisible(visible)
+        self.cancel_button.setVisible(visible)
         if visible:
             self.progress_bar.setRange(0, 0)
         else:
@@ -771,6 +779,10 @@ class MainWindow(QMainWindow):
     def set_progress(self, value: int, maximum: int = 100):
         self.progress_bar.setRange(0, maximum)
         self.progress_bar.setValue(value)
+
+    def _on_cancel_clicked(self):
+        if hasattr(self.stats_tab, "cancel_running"):
+            self.stats_tab.cancel_running()
 
     # ------------------------------------------------------------------
     # File / dialog actions

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -741,7 +741,7 @@ class MainWindow(QMainWindow):
         if step_key in next_tab_map:
             next_idx = next_tab_map[step_key]
             item = self._nav_list.item(next_idx)
-            if item and item.flags() & Qt.ItemIsEnabled:
+            if item and item.flags() & Qt.ItemFlag.ItemIsEnabled:
                 self._nav_list.setCurrentRow(next_idx)
 
         msg = self.tr("[{step}] Current shape: {n_samples} x {n_features}").format(

--- a/gui/stats_tab.py
+++ b/gui/stats_tab.py
@@ -31,10 +31,12 @@ class StatsTab(QWidget):
         self._rf_result = None
         self._outlier_result = None
         self._oplsda_result = None
+        self._clustering_result = None
         self._anova_plot_data = None
         self._anova_plot_labels = None
         self._outlier_labels = None
         self._active_workers: set[PipelineWorker] = set()
+        self._current_worker: PipelineWorker | None = None
         self._busy = False
         self._init_ui()
 
@@ -60,12 +62,21 @@ class StatsTab(QWidget):
         self.sub_tabs.addTab(self._build_rf_panel(), self.tr("Random Forest"))
         self.sub_tabs.addTab(self._build_outlier_panel(), self.tr("Outlier"))
         self.sub_tabs.addTab(self._build_oplsda_panel(), self.tr("OPLS-DA"))
+        self.sub_tabs.addTab(self._build_clustering_panel(), self.tr("Clustering"))
         layout.addWidget(self.sub_tabs)
 
     def retranslateUi(self):
-        current_idx = self.sub_tabs.currentIndex() if hasattr(self, "sub_tabs") else 0
-        self._init_ui()
-        self.sub_tabs.setCurrentIndex(min(current_idx, self.sub_tabs.count() - 1))
+        if not hasattr(self, "sub_tabs"):
+            return
+        tab_titles = [
+            self.tr("PCA"), self.tr("3D PCA"), self.tr("PLS-DA / VIP"),
+            self.tr("Volcano (t-test + FC)"), self.tr("ANOVA"), self.tr("ROC"),
+            self.tr("Correlation"), self.tr("Random Forest"),
+            self.tr("Outlier"), self.tr("OPLS-DA"), self.tr("Clustering"),
+        ]
+        for i, title in enumerate(tab_titles):
+            if i < self.sub_tabs.count():
+                self.sub_tabs.setTabText(i, title)
 
     def _snapshot_data(self):
         data = self.mw.current_data.copy()
@@ -117,6 +128,7 @@ class StatsTab(QWidget):
 
         worker = PipelineWorker(job_fn)
         self._active_workers.add(worker)
+        self._current_worker = worker
 
         def _handle_result(payload):
             try:
@@ -125,10 +137,14 @@ class StatsTab(QWidget):
                 QMessageBox.critical(self, error_title, str(exc))
 
         def _handle_error(error_text: str):
-            QMessageBox.critical(self, error_title, error_text)
+            if error_text == "Cancelled":
+                self.mw.status_bar.showMessage(self.tr("Analysis cancelled."))
+            else:
+                QMessageBox.critical(self, error_title, error_text)
 
         def _handle_finished():
             self._busy = False
+            self._current_worker = None
             self.sub_tabs.setEnabled(True)
             self.mw.show_progress(False)
             self._active_workers.discard(worker)
@@ -137,6 +153,12 @@ class StatsTab(QWidget):
         worker.signals.error.connect(_handle_error)
         worker.signals.finished.connect(_handle_finished)
         QThreadPool.globalInstance().start(worker)
+
+    def cancel_running(self):
+        """Cancel the currently running analysis, if any."""
+        if self._current_worker is not None:
+            self._current_worker.cancel()
+            self.mw.status_bar.showMessage(self.tr("Cancelling..."))
 
     # ?????????????????? PCA 2D ??????????????????
 
@@ -428,36 +450,18 @@ class StatsTab(QWidget):
         if self._plsda_result is None:
             return
         from visualization.vip_plot import plot_vip
-        import matplotlib.cm
 
         fig = self.pls_canvas.figure
         plot_key = self.pls_plot_type.currentData()
 
         if plot_key == "vip":
-            from core.shared_metadata import align_labels_to_data
             _data = self.mw.current_data
             _labels = align_labels_to_data(self.mw.current_data, self.mw.labels)
             plot_vip(self._plsda_result, top_n=self.vip_topn.value(),
                      data=_data, labels=_labels, theme=self._current_theme(), fig=fig)
         elif plot_key == "score":
-            fig.clear()
-            ax = fig.add_subplot(111)
-            scores = self._plsda_result.scores
-            labels = self._plsda_result.labels
-            labels_arr = labels.values if hasattr(labels, "values") else np.array(labels)
-            groups = sorted(set(labels_arr))
-            cmap = matplotlib.cm.Set1
-            for i, g in enumerate(groups):
-                mask = labels_arr == g
-                ax.scatter(scores[mask, 0], scores[mask, 1],
-                           c=[cmap(i / max(len(groups)-1, 1))],
-                           label=str(g), s=50, alpha=0.8)
-            ev = self._plsda_result.explained_variance
-            ax.set_xlabel(f"Comp1 ({ev[0]*100:.1f}%)" if len(ev) > 0 else "Comp1")
-            ax.set_ylabel(f"Comp2 ({ev[1]*100:.1f}%)" if len(ev) > 1 else "Comp2")
-            ax.set_title(self.tr("PLS-DA Score Plot"))
-            ax.legend()
-            fig.tight_layout()
+            from visualization.plsda_plot import plot_plsda_score
+            plot_plsda_score(self._plsda_result, theme=self._current_theme(), fig=fig)
         self.pls_canvas.draw()
         self.mw.show_shared_plot(self.pls_canvas.figure)
 
@@ -1543,6 +1547,116 @@ class StatsTab(QWidget):
             self.mw.status_bar.showMessage(self.tr("Saved: {path}").format(path=path))
 
     # ?????????????????? ?梁撌亙 ??????????????????
+
+    # ────────────────── Clustering ──────────────────
+
+    def _build_clustering_panel(self) -> QWidget:
+        w = QWidget()
+        layout = QVBoxLayout(w)
+
+        ctrl = QHBoxLayout()
+        ctrl.addWidget(QLabel(self.tr("Method:")))
+        self.clust_method = QComboBox()
+        self.clust_method.addItem("Ward", "ward")
+        self.clust_method.addItem("Complete", "complete")
+        self.clust_method.addItem("Average", "average")
+        self.clust_method.addItem("Single", "single")
+        ctrl.addWidget(self.clust_method)
+
+        ctrl.addWidget(QLabel(self.tr("Metric:")))
+        self.clust_metric = QComboBox()
+        self.clust_metric.addItem("Euclidean", "euclidean")
+        self.clust_metric.addItem("Correlation", "correlation")
+        self.clust_metric.addItem("Cosine", "cosine")
+        ctrl.addWidget(self.clust_metric)
+
+        ctrl.addWidget(QLabel(self.tr("Max features:")))
+        self.clust_maxfeat = QSpinBox()
+        self.clust_maxfeat.setRange(50, 10000)
+        self.clust_maxfeat.setValue(2000)
+        self.clust_maxfeat.setSingleStep(100)
+        ctrl.addWidget(self.clust_maxfeat)
+
+        btn_run = QPushButton(self.tr("Run Clustering"))
+        btn_run.clicked.connect(self._run_clustering)
+        ctrl.addWidget(btn_run)
+
+        ctrl.addWidget(QLabel(self.tr("Plot:")))
+        self.clust_plot_type = QComboBox()
+        self.clust_plot_type.addItem(self.tr("Dendrogram"), "dendrogram")
+        self.clust_plot_type.addItem(self.tr("Summary"), "summary")
+        self.clust_plot_type.currentIndexChanged.connect(self._update_clustering_plot)
+        ctrl.addWidget(self.clust_plot_type)
+
+        btn_save = QPushButton(self.tr("Export Figure"))
+        btn_save.clicked.connect(lambda: self._save_figure(self.clust_canvas))
+        ctrl.addWidget(btn_save)
+
+        layout.addLayout(ctrl)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        self.clust_canvas = MplWidget()
+        splitter.addWidget(self.clust_canvas)
+        self.clust_info = QTextEdit()
+        self.clust_info.setReadOnly(True)
+        self.clust_info.setMaximumWidth(300)
+        splitter.addWidget(self.clust_info)
+        layout.addWidget(splitter, stretch=1)
+        return w
+
+    def _run_clustering(self):
+        if not self.mw.check_data_ready():
+            return
+        from analysis.clustering import run_clustering
+
+        method = self.clust_method.currentData()
+        metric = self.clust_metric.currentData()
+        max_feat = self.clust_maxfeat.value()
+
+        data, labels, qc_meta = self._snapshot_stats_data_or_warn(require_labels=True)
+        if qc_meta is None:
+            return
+
+        def _job():
+            return run_clustering(
+                data, labels,
+                method=method, metric=metric,
+                max_features=max_feat,
+            )
+
+        def _on_success(result):
+            self._clustering_result = result
+            lines = [
+                self.tr("=== Clustering Results ==="),
+                self.tr("Method: {method}").format(method=result.method),
+                self.tr("Metric: {metric}").format(metric=result.metric),
+                self.tr("Samples: {n}").format(n=len(result.sample_names)),
+                self.tr("Features used: {n}").format(n=len(result.feature_names)),
+                self.tr("Clusters: {n}").format(n=result.n_clusters),
+                self.tr("Cophenetic correlation: {val}").format(
+                    val=f"{result.cophenetic_corr:.4f}"),
+                self._qc_scope_text(qc_meta["removed_qc"]),
+            ]
+            self.clust_info.setPlainText("\n".join(lines))
+            self._update_clustering_plot()
+
+        self._run_async(_job, _on_success, self.tr("Clustering Error"))
+
+    def _update_clustering_plot(self):
+        if self._clustering_result is None:
+            return
+        fig = self.clust_canvas.figure
+        plot_key = self.clust_plot_type.currentData()
+        if plot_key == "dendrogram":
+            from visualization.clustering_plot import plot_dendrogram
+            plot_dendrogram(self._clustering_result, theme=self._current_theme(), fig=fig)
+        else:
+            from visualization.clustering_plot import plot_cluster_summary
+            plot_cluster_summary(self._clustering_result, theme=self._current_theme(), fig=fig)
+        self.clust_canvas.draw()
+        self.mw.show_shared_plot(self.clust_canvas.figure)
+
+    # ────────────────── Common ──────────────────
 
     def _save_figure(self, canvas: MplWidget):
         path, _ = QFileDialog.getSaveFileName(

--- a/gui/stats_tab.py
+++ b/gui/stats_tab.py
@@ -1613,6 +1613,12 @@ class StatsTab(QWidget):
         metric = self.clust_metric.currentData()
         max_feat = self.clust_maxfeat.value()
 
+        if method == "ward" and metric != "euclidean":
+            metric = "euclidean"
+            self.clust_metric.setCurrentIndex(0)
+            self.mw.status_bar.showMessage(
+                self.tr("Ward linkage requires Euclidean distance. Metric reset to Euclidean."))
+
         data, labels, qc_meta = self._snapshot_stats_data_or_warn(require_labels=True)
         if qc_meta is None:
             return

--- a/gui/widgets/worker.py
+++ b/gui/widgets/worker.py
@@ -6,6 +6,10 @@ from PySide6.QtCore import QRunnable, Signal, QObject
 import traceback
 
 
+class CancelledError(Exception):
+    """Raised when a worker is cancelled."""
+
+
 class WorkerSignals(QObject):
     """Worker 信號集"""
     progress = Signal(int, str)    # (percentage, message)
@@ -23,6 +27,10 @@ class PipelineWorker(QRunnable):
         worker.signals.result.connect(on_result)
         worker.signals.error.connect(on_error)
         QThreadPool.globalInstance().start(worker)
+
+    取消：
+        worker.cancel()  # 設定取消旗標
+        # 長時間作業可透過 worker.is_cancelled() 主動檢查
     """
 
     def __init__(self, fn, *args, **kwargs):
@@ -31,13 +39,28 @@ class PipelineWorker(QRunnable):
         self.args = args
         self.kwargs = kwargs
         self.signals = WorkerSignals()
+        self._cancelled = False
         self.setAutoDelete(True)
+
+    def cancel(self):
+        """Request cancellation. The running function must check is_cancelled()."""
+        self._cancelled = True
+
+    def is_cancelled(self) -> bool:
+        """Return True if cancellation has been requested."""
+        return self._cancelled
 
     def run(self):
         try:
             result = self.fn(*self.args, **self.kwargs)
-            self.signals.result.emit(result)
+            if self._cancelled:
+                self.signals.error.emit("Cancelled")
+            else:
+                self.signals.result.emit(result)
+        except CancelledError:
+            self.signals.error.emit("Cancelled")
         except Exception:
-            self.signals.error.emit(traceback.format_exc())
+            if not self._cancelled:
+                self.signals.error.emit(traceback.format_exc())
         finally:
             self.signals.finished.emit()

--- a/ms_core/visualization/__init__.py
+++ b/ms_core/visualization/__init__.py
@@ -7,6 +7,7 @@ import sys
 _ALIASES = {
     "anova_plot": "visualization.anova_plot",
     "boxplot": "visualization.boxplot",
+    "clustering_plot": "visualization.clustering_plot",
     "correlation_plot": "visualization.correlation_plot",
     "density_plot": "visualization.density_plot",
     "heatmap": "visualization.heatmap",
@@ -15,6 +16,7 @@ _ALIASES = {
     "outlier_plot": "visualization.outlier_plot",
     "pca_3d": "visualization.pca_3d",
     "pca_plot": "visualization.pca_plot",
+    "plsda_plot": "visualization.plsda_plot",
     "rf_plot": "visualization.rf_plot",
     "roc_plot": "visualization.roc_plot",
     "vip_plot": "visualization.vip_plot",

--- a/visualization/clustering_plot.py
+++ b/visualization/clustering_plot.py
@@ -56,9 +56,10 @@ def plot_dendrogram(
     group_color_map = dict(zip(groups, colors))
 
     n_samples = len(clustering_result.sample_names)
+    show_group_suffix = n_samples <= 80
     sample_labels = [
         f"{clustering_result.sample_names[i]} ({labels_arr[i]})"
-        if n_samples <= 50
+        if show_group_suffix
         else str(clustering_result.sample_names[i])
         for i in range(n_samples)
     ]

--- a/visualization/clustering_plot.py
+++ b/visualization/clustering_plot.py
@@ -1,0 +1,179 @@
+"""Dendrogram and cluster summary plots for hierarchical clustering."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
+from scipy.cluster.hierarchy import dendrogram
+
+from visualization.theme import apply_publication_style, get_group_colors
+
+
+def plot_dendrogram(
+    clustering_result,
+    orientation: str = "top",
+    truncate_mode: str | None = None,
+    p: int = 30,
+    theme: str = "light",
+    fig: Figure | None = None,
+) -> Figure:
+    """
+    Plot a sample dendrogram from hierarchical clustering results.
+
+    Parameters
+    ----------
+    clustering_result : ClusteringResult
+        Result object returned by ``analysis.clustering.run_clustering``.
+    orientation : str, default="top"
+        Dendrogram orientation: "top", "bottom", "left", "right".
+    truncate_mode : str or None, default=None
+        Truncation mode passed to ``scipy.cluster.hierarchy.dendrogram``.
+        Use ``"lastp"`` with ``p`` to show only the last ``p`` merged clusters.
+    p : int, default=30
+        Number of leaf nodes to show when truncate_mode is "lastp".
+    theme : str, default="light"
+        Visualization theme name.
+    fig : Figure or None, default=None
+        Existing figure to reuse.
+
+    Returns
+    -------
+    Figure
+        The rendered matplotlib figure.
+    """
+    apply_publication_style(theme)
+
+    if fig is None:
+        fig, ax = plt.subplots(figsize=(10, 6))
+    else:
+        fig.clear()
+        ax = fig.add_subplot(111)
+
+    labels_arr = clustering_result.labels
+    groups = sorted(set(labels_arr))
+    colors = get_group_colors(theme, len(groups))
+    group_color_map = dict(zip(groups, colors))
+
+    n_samples = len(clustering_result.sample_names)
+    sample_labels = [
+        f"{clustering_result.sample_names[i]} ({labels_arr[i]})"
+        if n_samples <= 50
+        else str(clustering_result.sample_names[i])
+        for i in range(n_samples)
+    ]
+
+    dend_kwargs = dict(
+        Z=clustering_result.row_linkage,
+        labels=sample_labels,
+        orientation=orientation,
+        leaf_rotation=90 if orientation in ("top", "bottom") else 0,
+        leaf_font_size=max(6, min(9, 300 // max(n_samples, 1))),
+        ax=ax,
+        above_threshold_color="grey",
+    )
+    if truncate_mode is not None:
+        dend_kwargs["truncate_mode"] = truncate_mode
+        dend_kwargs["p"] = p
+
+    dendrogram(**dend_kwargs)
+
+    # Color leaf labels by group
+    if n_samples <= 80:
+        xlabels = ax.get_xticklabels() if orientation in ("top", "bottom") else ax.get_yticklabels()
+        for lbl in xlabels:
+            text = lbl.get_text()
+            for group in groups:
+                if f"({group})" in text:
+                    lbl.set_color(group_color_map[group])
+                    break
+
+    ax.set_title(
+        f"Dendrogram ({clustering_result.method} / {clustering_result.metric})"
+    )
+
+    # Add legend for groups
+    from matplotlib.patches import Patch
+    legend_elements = [
+        Patch(facecolor=group_color_map[g], label=str(g)) for g in groups
+    ]
+    ax.legend(
+        handles=legend_elements, loc="upper right", fontsize=8, title="Group"
+    )
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_cluster_summary(
+    clustering_result,
+    theme: str = "light",
+    fig: Figure | None = None,
+) -> Figure:
+    """
+    Plot a cluster-vs-group contingency bar chart and cophenetic info.
+
+    Parameters
+    ----------
+    clustering_result : ClusteringResult
+        Result object returned by ``analysis.clustering.run_clustering``.
+    theme : str, default="light"
+        Visualization theme name.
+    fig : Figure or None, default=None
+        Existing figure to reuse.
+
+    Returns
+    -------
+    Figure
+        The rendered matplotlib figure.
+    """
+    apply_publication_style(theme)
+
+    if fig is None:
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+    else:
+        fig.clear()
+        ax1 = fig.add_subplot(121)
+        ax2 = fig.add_subplot(122)
+
+    labels_arr = clustering_result.labels
+    groups = sorted(set(labels_arr))
+    clusters = sorted(set(clustering_result.row_clusters))
+    colors = get_group_colors(theme, len(groups))
+
+    # Stacked bar: cluster membership by group
+    bar_width = 0.6
+    x = np.arange(len(clusters))
+    bottoms = np.zeros(len(clusters))
+
+    for g_idx, group in enumerate(groups):
+        counts = []
+        for c in clusters:
+            mask = (clustering_result.row_clusters == c) & (labels_arr == group)
+            counts.append(int(mask.sum()))
+        ax1.bar(x, counts, bar_width, bottom=bottoms, label=str(group), color=colors[g_idx])
+        bottoms += np.array(counts)
+
+    ax1.set_xticks(x)
+    ax1.set_xticklabels([f"C{c}" for c in clusters])
+    ax1.set_xlabel("Cluster")
+    ax1.set_ylabel("Count")
+    ax1.set_title("Cluster Composition by Group")
+    ax1.legend(fontsize=8, title="Group")
+
+    # Cluster size pie chart
+    cluster_sizes = [int((clustering_result.row_clusters == c).sum()) for c in clusters]
+    wedge_colors = get_group_colors(theme, len(clusters))
+    ax2.pie(
+        cluster_sizes,
+        labels=[f"C{c} (n={s})" for c, s in zip(clusters, cluster_sizes)],
+        colors=wedge_colors,
+        autopct="%1.0f%%",
+        startangle=90,
+    )
+    ax2.set_title(
+        f"Cluster Sizes\n(cophenetic r = {clustering_result.cophenetic_corr:.3f})"
+    )
+
+    fig.tight_layout()
+    return fig

--- a/visualization/plsda_plot.py
+++ b/visualization/plsda_plot.py
@@ -1,0 +1,101 @@
+"""PLS-DA score plot with per-group confidence ellipses."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
+from matplotlib.patches import Ellipse
+from scipy.stats import chi2
+
+from visualization.theme import apply_publication_style, get_group_colors
+
+
+def plot_plsda_score(
+    plsda_result,
+    comp_x: int = 0,
+    comp_y: int = 1,
+    theme: str = "light",
+    fig: Figure | None = None,
+) -> Figure:
+    """
+    Plot PLS-DA score chart with per-group 95% confidence ellipses.
+
+    Parameters
+    ----------
+    plsda_result : PLSDAResult
+        Result object returned by ``analysis.plsda.run_plsda``.
+    comp_x : int, default=0
+        Zero-based component index for x-axis.
+    comp_y : int, default=1
+        Zero-based component index for y-axis.
+    theme : str, default="light"
+        Visualization theme name.
+    fig : Figure or None, default=None
+        Existing figure to reuse.  When ``None``, a new figure is created.
+
+    Returns
+    -------
+    Figure
+        The rendered matplotlib figure.
+    """
+    apply_publication_style(theme)
+
+    if fig is None:
+        fig, ax = plt.subplots(figsize=(8, 6))
+    else:
+        fig.clear()
+        ax = fig.add_subplot(111)
+
+    scores = plsda_result.scores
+    labels = plsda_result.labels
+    ev = plsda_result.explained_variance
+    labels_arr = labels.values if hasattr(labels, "values") else np.asarray(labels)
+    groups = sorted(set(labels_arr))
+    colors = get_group_colors(theme, len(groups))
+
+    for idx, group in enumerate(groups):
+        mask = labels_arr == group
+        x = scores[mask, comp_x]
+        y = scores[mask, comp_y]
+        ax.scatter(
+            x,
+            y,
+            c=[colors[idx]],
+            label=str(group),
+            s=60,
+            alpha=0.8,
+            edgecolors="white",
+            linewidth=0.5,
+        )
+
+        if len(x) > 2:
+            cov = np.cov(x, y)
+            if np.linalg.det(cov) > 1e-10:
+                eig_vals, eig_vecs = np.linalg.eigh(cov)
+                angle = np.degrees(np.arctan2(*eig_vecs[:, 1][::-1]))
+                n_std = np.sqrt(chi2.ppf(0.95, 2))
+                width, height = 2 * n_std * np.sqrt(np.abs(eig_vals))
+                ax.add_patch(
+                    Ellipse(
+                        xy=(x.mean(), y.mean()),
+                        width=width,
+                        height=height,
+                        angle=angle,
+                        edgecolor=colors[idx],
+                        facecolor="none",
+                        linestyle="--",
+                        linewidth=1.5,
+                    )
+                )
+
+    x_label = f"Comp1 ({ev[0] * 100:.1f}%)" if len(ev) > 0 else "Comp1"
+    y_label = f"Comp2 ({ev[1] * 100:.1f}%)" if len(ev) > 1 else "Comp2"
+    ax.set_xlabel(x_label)
+    ax.set_ylabel(y_label)
+    ax.set_title("PLS-DA Score Plot")
+    ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", borderaxespad=0.0, fontsize=9)
+    ax.axhline(0, color="grey", linewidth=0.5, linestyle=":")
+    ax.axvline(0, color="grey", linewidth=0.5, linestyle=":")
+    fig.tight_layout()
+    return fig

--- a/visualization/plsda_plot.py
+++ b/visualization/plsda_plot.py
@@ -89,8 +89,8 @@ def plot_plsda_score(
                     )
                 )
 
-    x_label = f"Comp1 ({ev[0] * 100:.1f}%)" if len(ev) > 0 else "Comp1"
-    y_label = f"Comp2 ({ev[1] * 100:.1f}%)" if len(ev) > 1 else "Comp2"
+    x_label = f"Comp{comp_x + 1} ({ev[comp_x] * 100:.1f}%)" if len(ev) > comp_x else f"Comp{comp_x + 1}"
+    y_label = f"Comp{comp_y + 1} ({ev[comp_y] * 100:.1f}%)" if len(ev) > comp_y else f"Comp{comp_y + 1}"
     ax.set_xlabel(x_label)
     ax.set_ylabel(y_label)
     ax.set_title("PLS-DA Score Plot")


### PR DESCRIPTION
## Summary
- **P0 bug fix**: Remove dead `core.shared_metadata` import that caused `ModuleNotFoundError` when rendering PLS-DA VIP plot
- **P1 doc sync**: Update CLAUDE.md to reflect actual tech stack (PySide6, not PyQt6)
- **P1 architecture**: Extract inline PLS-DA score plot to `visualization/plsda_plot.py` with 95% confidence ellipses, consistent with `pca_plot.py` style
- **P2 state preservation**: Fix `stats_tab.retranslateUi()` — now updates tab titles only instead of rebuilding entire UI (which destroyed analysis results on language switch)
- **P3 new feature**: Add Clustering sub-tab in Statistics with dendrogram + cluster summary visualization (`analysis/clustering.py` + `visualization/clustering_plot.py`)
- **P3 new feature**: Add cancel mechanism — `PipelineWorker.cancel()` + Cancel button in status bar during async analysis

## Changed files
| File | Change |
|------|--------|
| `gui/stats_tab.py` | Fix dead import, extract PLS-DA plot, fix retranslateUi, add Clustering sub-tab, add cancel support |
| `gui/main_window.py` | Add Cancel button to status bar, toggle with progress bar |
| `gui/widgets/worker.py` | Add `cancel()` / `is_cancelled()` + `CancelledError` |
| `analysis/clustering.py` | Add `ClusteringResult` dataclass + `run_clustering()` |
| `visualization/plsda_plot.py` | **New** — PLS-DA score plot with confidence ellipses |
| `visualization/clustering_plot.py` | **New** — Dendrogram + cluster summary plots |
| `analysis/__init__.py` | Export new clustering symbols |
| `ms_core/visualization/__init__.py` | Add compat aliases for new viz modules |
| `claude.md` | PyQt6 → PySide6 |

## Test plan
- [x] All 322 existing tests pass (5 skipped), zero regression
- [x] New modules import correctly via both `visualization.*` and `ms_core.visualization.*`
- [x] `run_clustering()` produces valid `ClusteringResult` with cophenetic correlation
- [x] `plot_dendrogram()` and `plot_cluster_summary()` render correctly
- [x] `plot_plsda_score()` renders with confidence ellipses
- [x] `PipelineWorker.cancel()` sets flag, error handler shows "Cancelled" instead of traceback
- [ ] Manual: verify Clustering tab in GUI (Run Clustering → Dendrogram / Summary toggle)
- [ ] Manual: verify Cancel button appears during analysis and cancels cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)