### PR TITLE
feat: add publication batch report exports and run.cmd workflow guidance

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4,8 +4,8 @@
 
 - **core/** — pure-function processing modules (normalization, transformation, scaling, etc.)
 - **analysis/** — statistical analysis (PCA, PLS-DA, univariate, clustering)
-- **visualization/** — matplotlib Figure objects returned by each module
-- **gui/** — PyQt6 GUI layer only (no processing logic here)
+- **visualization/** — matplotlib and Plotly rendering helpers used by GUI previews, exports, and reports
+- **gui/** — PySide6 GUI layer only (no processing logic here)
 - **tests/** — pytest test suite
 
 ## Development Workflow
@@ -14,7 +14,7 @@
 
 Before ANY development work, always run:
 
-```bash
+```powershell
 git status
 ```
 
@@ -35,7 +35,7 @@ git status
 
 Use git worktree for isolation (`.worktrees/` is already in `.gitignore`):
 
-```bash
+```powershell
 git worktree add .worktrees/<branch-name> -b <type>/<branch-name>
 ```
 
@@ -43,13 +43,32 @@ Use the `superpowers:using-git-worktrees` skill for guided setup.
 
 ### 3. Develop and Test
 
-Run the full test suite before considering work complete:
+Do not default to a single monolithic `pytest tests/ ...` run in this repo.
 
-```bash
-pytest tests/ -v --tb=short -x
+This repository contains GUI-heavy and matrix-heavy test slices that can look hung or exceed harness limits when run as one large command, especially on self-hosted Windows CI. Prefer targeted verification first, then run the matching CI-style shard wrapper.
+
+Recommended order:
+
+1. Run the smallest test slice that directly covers the change.
+2. Run the matching CI shard with `tools\ci\run_pytest_targets.ps1`.
+3. Only use broader file-by-file aggregation when you need wider regression confidence.
+
+Representative commands:
+
+```powershell
+# Targeted test during implementation
+uv run pytest tests\test_gui_step5_interaction.py -q
+
+# CI-equivalent PR shards
+tools\ci\run_pytest_targets.ps1 -GroupNames @("pr-gui-shell")
+tools\ci\run_pytest_targets.ps1 -GroupNames @("pr-stats")
+tools\ci\run_pytest_targets.ps1 -GroupNames @("pr-runtime")
+
+# Broader file-by-file aggregation when needed
+Get-ChildItem tests -Filter "test_*.py" | Sort-Object Name | ForEach-Object { uv run pytest $_.FullName -q }
 ```
 
-All tests must pass.
+All tests relevant to the current change must pass before considering work complete.
 
 ### 4. Finish Branch
 
@@ -82,36 +101,39 @@ When ms-core submodule is added:
 - **NO** force push to `main`
 - **NO** merging without passing tests
 - **NO** skipping `git status` check before starting work
+- **NO** relying on bare `window.close()` as the only teardown step in Qt GUI tests
 
 ## Key Commands
 
-```bash
+```powershell
 # Run tests
-pytest tests/ -v --tb=short -x
+uv run pytest tests\test_gui_step5_interaction.py -q
 
-# Run tests in the supported CI matrix locally when needed
-uv run pytest tests/ -v --tb=short -x
+# Run CI-equivalent PR shards locally
+tools\ci\run_pytest_targets.ps1 -GroupNames @("pr-gui-shell")
+tools\ci\run_pytest_targets.ps1 -GroupNames @("pr-stats")
+tools\ci\run_pytest_targets.ps1 -GroupNames @("pr-runtime")
 
-# CI-style full regression
+# Broader file-by-file regression
 Get-ChildItem tests -Filter "test_*.py" | Sort-Object Name | ForEach-Object { uv run pytest $_.FullName -q }
 
 # Preferred stable wrapper (Windows)
 scripts\run_pipeline.cmd -Config configs\Tissue_knn_rsd050_marker_verify.yaml -Input "C:\path\to\input.xlsx"
 
 # Run pipeline from YAML
-python scripts/run_from_config.py <config.yaml>
+uv run python scripts\run_from_config.py <config.yaml>
 
 # Run pipeline with an explicit input workbook override
-python scripts/run_from_config.py <config.yaml> --input "<path-to-input.xlsx>"
+uv run python scripts\run_from_config.py <config.yaml> --input "<path-to-input.xlsx>"
 
 # Run pipeline with an input override and output suffix override
-python scripts/run_from_config.py <config.yaml> --input "<path-to-input.xlsx>" --suffix "_custom"
+uv run python scripts\run_from_config.py <config.yaml> --input "<path-to-input.xlsx>" --suffix "_custom"
 
 # Build exe locally (Windows)
-pyinstaller packaging/pymetabo.spec --clean --noconfirm
+pyinstaller packaging\pymetabo.spec --clean --noconfirm
 
 # Build CI-compatible release package locally
-pyinstaller packaging/pymetabo_release.spec --clean --noconfirm
+pyinstaller packaging\pymetabo_release.spec --clean --noconfirm
 
 # Lint
 ruff check . --select=F,E9
@@ -138,13 +160,13 @@ and execute it directly without re-discovering project structure.
 
 Default command mapping:
 
-```bash
+```powershell
 run.cmd "<input.xlsx>" "<config.yaml>"
 ```
 
 If the user also asks for a custom output suffix:
 
-```bash
+```powershell
 run.cmd "<input.xlsx>" "<config.yaml>" -Suffix "_custom"
 ```
 
@@ -154,7 +176,7 @@ Do not spend time re-finding the CLI entry point, config parameter name, or inpu
 
 For requests phrased with input first and config second, prefer:
 
-```bash
+```powershell
 run.cmd "<input.xlsx>" "<config.yaml>"
 ```
 
@@ -166,24 +188,24 @@ run.cmd "<input.xlsx>" "<config.yaml>"
 
 Prefer this wrapper unless there is a specific reason to call the Python entry point directly:
 
-```bash
+```powershell
 scripts\run_pipeline.cmd -Config <config.yaml> -Input "<input.xlsx>" [-Suffix "_tag"]
 ```
 
 - This wrapper resolves relative paths from the repo root.
 - It validates that the config and input files exist before starting Python.
-- It forwards arguments to `scripts/run_from_config.py`.
-- The `.cmd` wrapper delegates to `scripts/run_pipeline.py`, which is more reliable than raw shell argument forwarding on Windows.
+- It forwards arguments to `scripts\run_from_config.py`.
+- The `.cmd` wrapper delegates to `scripts\run_pipeline.py`, which is more reliable than raw shell argument forwarding on Windows.
 
 ### Canonical CLI Entry Point
 
 Always use:
 
-```bash
-python scripts/run_from_config.py <config.yaml> [--input "<input.xlsx>"] [--suffix "_tag"]
+```powershell
+uv run python scripts\run_from_config.py <config.yaml> [--input "<input.xlsx>"] [--suffix "_tag"]
 ```
 
-- Script entry point: `scripts/run_from_config.py`
+- Script entry point: `scripts\run_from_config.py`
 - Required positional argument: `config`
 - Optional input override: `--input` or `-i`
 - Optional output suffix override: `--suffix` or `-s`
@@ -226,7 +248,7 @@ Do not re-discover this in later sessions unless the script changes.
 
 ### Example
 
-```bash
+```powershell
 run.cmd "C:\Users\user\Desktop\Data_Normalization_project_v2\.worktrees\refactor-step4-pqn-only\output\run_20260331_190146\Step4_Normalized_PQN.xlsx" "configs\Tissue_knn_rsd050_marker_verify.yaml"
 ```
 
@@ -258,3 +280,48 @@ Examples:
 | `release-checklist` | Executing a versioned release |
 | `submodule-update` | When ms-core is modified (after submodule added) |
 | `root-hygiene` | When temp files pollute repository root |
+| `run-cmd-contract` | When the user phrases pipeline execution as `用這個 xlsx 跑這個 yaml` or equivalent |
+
+## GUI / CI Guardrails
+
+### Qt GUI Test Teardown
+
+- For PySide / Qt GUI tests, do not stop at bare `window.close()`.
+- Prefer the shared cleanup helper in `tests\gui_layout_support.py`.
+- The expected teardown shape is:
+
+```python
+window.close()
+window.deleteLater()
+QCoreApplication.sendPostedEvents(None, int(QEvent.Type.DeferredDelete))
+qapp.processEvents()
+```
+
+- If GUI tests get slower the further they progress, first suspect leaked Qt windows, timers, theme callbacks, or log handlers before blaming the runner.
+
+### MainWindow Lifecycle
+
+- When changing `gui\main_window.py`, always review lifecycle symmetry:
+  - timers created during setup
+  - theme-manager callback registration / unregistration
+  - log handler add / remove
+  - worker cancellation on close
+- If a new resource is created in `__init__` or UI setup, its cleanup path must be explicit.
+
+### Interactive Plot Routing
+
+- For Step 5 score plots, assume the GUI may route to interactive Plotly first and only fall back to Matplotlib when needed.
+- When updating tests around PCA / PLS-DA / OPLS-DA / Volcano, verify both:
+  - the primary interactive path
+  - the fallback static path
+- If a test only monkeypatches a legacy Matplotlib helper such as `plot_pca_score`, treat it as suspicious and confirm the real runtime path first.
+
+### CI Refactor Discipline
+
+- When changing CI job names or shard topology, also check branch protection / rulesets for required status-check drift.
+- Keep one stable aggregate PR gate name whenever possible. In this repo, the canonical aggregate gate is:
+  - `Full Regression (Python 3.11)`
+- Treat a long-running `in_progress` PR check as a debugging prompt, not automatic evidence that GitHub Actions itself is broken:
+  1. reproduce with the equivalent local shard
+  2. identify whether the slowdown is test runtime, repeated setup, or lifecycle leakage
+  3. only then change workflow topology if needed

--- a/analysis/random_forest.py
+++ b/analysis/random_forest.py
@@ -83,6 +83,108 @@ def _clean_feature_dataframe(df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
     return out, dropped
 
 
+def _build_rf_model(
+    *,
+    n_trees: int,
+    random_state: int,
+    n_jobs: int,
+) -> RandomForestClassifier:
+    """Build a Random Forest classifier with a specific parallelism setting."""
+    return RandomForestClassifier(
+        n_estimators=n_trees,
+        oob_score=True,
+        random_state=random_state,
+        n_jobs=n_jobs,
+    )
+
+
+def _run_rf_with_n_jobs(
+    *,
+    X: np.ndarray,
+    y: np.ndarray,
+    class_names: list[str],
+    feature_names: list[str],
+    dropped_unnamed: int,
+    n_trees: int,
+    cv_folds: int,
+    top_n: int,
+    random_state: int,
+    n_jobs: int,
+) -> RFResult:
+    """Execute Random Forest analysis with an explicit n_jobs setting."""
+    rf = _build_rf_model(
+        n_trees=n_trees,
+        random_state=random_state,
+        n_jobs=n_jobs,
+    )
+    rf.fit(X, y)
+    oob_acc = float(rf.oob_score_)
+
+    used_folds = _get_cv_folds(y, cv_folds)
+    if used_folds >= 2:
+        cv = StratifiedKFold(
+            n_splits=used_folds,
+            shuffle=True,
+            random_state=random_state,
+        )
+        cv_scores = cross_val_score(
+            _build_rf_model(
+                n_trees=n_trees,
+                random_state=random_state,
+                n_jobs=n_jobs,
+            ),
+            X,
+            y,
+            cv=cv,
+            scoring="accuracy",
+            n_jobs=n_jobs,
+        )
+        cv_acc = float(cv_scores.mean())
+        cv_std = float(cv_scores.std())
+        y_pred = cross_val_predict(
+            _build_rf_model(
+                n_trees=n_trees,
+                random_state=random_state,
+                n_jobs=n_jobs,
+            ),
+            X,
+            y,
+            cv=cv,
+            n_jobs=n_jobs,
+        )
+        cm = confusion_matrix(y, y_pred)
+    else:
+        # Not enough samples per class for CV; fall back to in-sample prediction.
+        cv_acc = float("nan")
+        cv_std = float("nan")
+        cm = confusion_matrix(y, rf.predict(X))
+
+    feature_cap = int(max(1, min(top_n, len(feature_names))))
+    importance_df = (
+        pd.DataFrame(
+            {
+                "Feature": feature_names,
+                "Importance": rf.feature_importances_,
+            }
+        )
+        .sort_values("Importance", ascending=False)
+        .reset_index(drop=True)
+        .head(feature_cap)
+    )
+
+    return RFResult(
+        feature_importance=importance_df,
+        oob_accuracy=oob_acc,
+        cv_accuracy=cv_acc,
+        cv_std=cv_std,
+        cv_folds_used=used_folds,
+        confusion_mat=cm,
+        class_names=class_names,
+        model=rf,
+        dropped_unnamed_features=dropped_unnamed,
+    )
+
+
 def run_random_forest(
     df: pd.DataFrame,
     labels: pd.Series,
@@ -102,55 +204,35 @@ def run_random_forest(
     y = le.fit_transform(labels)
     X = clean_df.values
     class_names = list(le.classes_)
+    requested_n_jobs = _N_JOBS
 
-    rf = RandomForestClassifier(
-        n_estimators=n_trees,
-        oob_score=True,
-        random_state=random_state,
-        n_jobs=_N_JOBS,
-    )
-    rf.fit(X, y)
-    oob_acc = float(rf.oob_score_)
-
-    used_folds = _get_cv_folds(y, cv_folds)
-    if used_folds >= 2:
-        cv = StratifiedKFold(
-            n_splits=used_folds,
-            shuffle=True,
+    try:
+        return _run_rf_with_n_jobs(
+            X=X,
+            y=y,
+            class_names=class_names,
+            feature_names=clean_df.columns.astype(str).tolist(),
+            dropped_unnamed=dropped_unnamed,
+            n_trees=n_trees,
+            cv_folds=cv_folds,
+            top_n=top_n,
             random_state=random_state,
+            n_jobs=requested_n_jobs,
         )
-        cv_scores = cross_val_score(rf, X, y, cv=cv, scoring="accuracy", n_jobs=_N_JOBS)
-        cv_acc = float(cv_scores.mean())
-        cv_std = float(cv_scores.std())
-        y_pred = cross_val_predict(rf, X, y, cv=cv, n_jobs=_N_JOBS)
-        cm = confusion_matrix(y, y_pred)
-    else:
-        # Not enough samples per class for CV; fall back to in-sample prediction.
-        cv_acc = float("nan")
-        cv_std = float("nan")
-        cm = confusion_matrix(y, rf.predict(X))
-
-    top_n = int(max(1, min(top_n, clean_df.shape[1])))
-    importance_df = (
-        pd.DataFrame(
-            {
-                "Feature": clean_df.columns,
-                "Importance": rf.feature_importances_,
-            }
+    except PermissionError:
+        # Windows sandboxed or packaged environments can deny the internal
+        # multiprocessing queue creation used by joblib when n_jobs != 1.
+        if requested_n_jobs == 1:
+            raise
+        return _run_rf_with_n_jobs(
+            X=X,
+            y=y,
+            class_names=class_names,
+            feature_names=clean_df.columns.astype(str).tolist(),
+            dropped_unnamed=dropped_unnamed,
+            n_trees=n_trees,
+            cv_folds=cv_folds,
+            top_n=top_n,
+            random_state=random_state,
+            n_jobs=1,
         )
-        .sort_values("Importance", ascending=False)
-        .reset_index(drop=True)
-        .head(top_n)
-    )
-
-    return RFResult(
-        feature_importance=importance_df,
-        oob_accuracy=oob_acc,
-        cv_accuracy=cv_acc,
-        cv_std=cv_std,
-        cv_folds_used=used_folds,
-        confusion_mat=cm,
-        class_names=class_names,
-        model=rf,
-        dropped_unnamed_features=dropped_unnamed,
-    )

--- a/docs/plans/2026-04-11-publication-batch-report-v1.md
+++ b/docs/plans/2026-04-11-publication-batch-report-v1.md
@@ -1,0 +1,242 @@
+# Publication-Oriented Batch Report V1
+
+## Goal
+
+Refactor the `run.cmd` / `scripts\run_from_config.py` batch output into a
+publication-oriented report layout that:
+
+- removes low-value or redundant figures
+- adds a small set of high-value figures already supported by the codebase
+- groups outputs by analysis narrative instead of dumping every artifact into one folder
+- keeps the existing `run.cmd "<input.xlsx>" "<config.yaml>"` contract unchanged
+
+## Scope
+
+This iteration targets the CLI batch report only.
+
+Included:
+
+- batch output folder restructuring
+- figure selection cleanup
+- new core figures wired into batch export
+- supplementary figure export for secondary evidence
+
+Excluded:
+
+- GUI changes
+- HTML dashboard / report index
+- new report-profile schema
+- interactive-only charts as part of batch defaults
+
+## Output Policy
+
+### Remove From Default Batch Output
+
+- `PCA Scree Plot`
+- `PCA Loading Plot`
+- standalone `Sample Boxplot`
+- standalone `Density Plot`
+- `PLS-DA Pairwise Score Plot`
+
+### Core Report
+
+- `Normalization Comparison Plot`
+- `PCA Score Plot`
+- `OPLS-DA Pairwise Score Plot`
+- `OPLS-DA S-Plot`
+- `Volcano Plot`
+- `PLS-DA VIP Plot`
+- `Heatmap`
+- `ROC Curve`
+- `AUC Ranking Bar Plot`
+- `ANOVA Importance Plot`
+
+### Supplementary / Advanced
+
+- `PLS-DA All-Groups Score Plot`
+- `Outlier T2 Plot`
+- `DModX Plot`
+- `Random Forest Feature Importance Plot`
+- `Random Forest Confusion Matrix`
+- `ANOVA Feature Boxplots`
+
+### Not Included In Batch V1
+
+- `3D PCA Plot`
+- `Correlation Network`
+- `Correlation Heatmap`
+- `Clustering Dendrogram`
+- `Clustering Summary Plot`
+
+## Folder Structure
+
+The output directory should be reorganized into these subfolders:
+
+```text
+<output_dir>/
+  01_QC_and_Preprocessing/
+  02_Global_Profiling/
+  03_Feature_Selection/
+  04_Biomarker_Validation/
+  05_Supplementary/
+```
+
+### 01_QC_and_Preprocessing
+
+- `normalization_comparison.png`
+- `pca_score_plot.png`
+
+### 02_Global_Profiling
+
+- `heatmap_top50.png`
+
+### 03_Feature_Selection
+
+- `oplsda_score_{g1}_vs_{g2}.png`
+- `oplsda_splot_{g1}_vs_{g2}.png`
+- `volcano_{g1}_vs_{g2}.png`
+- `plsda_vip_{g1}_vs_{g2}.png`
+- `anova_importance.png`
+
+### 04_Biomarker_Validation
+
+- `roc_{g1}_vs_{g2}.png`
+- `auc_ranking_{g1}_vs_{g2}.png`
+
+### 05_Supplementary
+
+- `plsda_score_all_groups.png`
+- `outlier_t2.png`
+- `outlier_dmodx.png`
+- `rf_importance_{g1}_vs_{g2}.png`
+- `rf_confusion_matrix_{g1}_vs_{g2}.png`
+- `anova_boxplot_{g1}_vs_{g2}_top{n}.png`
+
+## Export Limits
+
+- Heatmap should be limited to `Top 30-50` features.
+  - V1 default: `Top 50`
+- ANOVA boxplots should be limited.
+  - V1 default: `Top 10`
+- ROC / AUC / Random Forest should be pairwise only.
+- OPLS-DA remains the pairwise supervised score plot used in the core report.
+- PLS-DA all-groups score plot remains supplementary only.
+
+## Implementation Notes
+
+### 1. Batch Runner
+
+Primary integration point:
+
+- `scripts\run_from_config.py`
+
+Required changes:
+
+- add a helper that creates the new report subdirectories
+- route figure outputs into the new subdirectories
+- stop exporting removed default figures
+- keep CSV / Excel / config artifacts at the report root unless a better grouping is obvious
+
+### 2. Normalization Comparison
+
+Primary module:
+
+- `visualization\norm_preview.py`
+
+Requirements:
+
+- show a real before/after comparison
+- prefer compact, publication-friendly layout
+- compare preprocessing state before normalization-related operations against the final processed matrix
+- replace the old standalone sample distribution figures in the default report
+
+### 3. Heatmap
+
+Primary module:
+
+- `visualization\heatmap.py`
+
+Requirements:
+
+- batch export only
+- static figure only
+- use a stable feature-selection rule
+
+V1 feature-selection rule:
+
+- prefer ANOVA-significant features when available
+- otherwise fall back to top variable features
+- cap the rendered features at 50
+
+### 4. OPLS-DA S-Plot
+
+Primary module:
+
+- `visualization\oplsda_plot.py`
+
+Requirements:
+
+- export alongside each pairwise OPLS-DA score plot
+- stable annotation behavior
+- readable labels even with dense feature clouds
+
+### 5. ROC / AUC
+
+Primary module:
+
+- `visualization\roc_plot.py`
+
+Requirements:
+
+- export both `ROC Curve` and `AUC Ranking`
+- pairwise only
+- output into `04_Biomarker_Validation`
+
+### 6. Supplementary Figures
+
+Supplementary exports should be informative but not overwhelm the core report.
+
+V1 contents:
+
+- all-groups PLS-DA score
+- outlier plots
+- random forest plots
+- top-10 ANOVA feature boxplots
+
+## Validation Targets
+
+Use `configs\Tissue_knn_rsd050_marker_verify.yaml` as the first validation profile.
+
+Validation should confirm:
+
+- new folder structure exists
+- removed default figures are no longer produced
+- core report figures exist in the expected subfolders
+- supplementary figures exist in the expected subfolder
+- existing tabular outputs still exist
+
+## Suggested Work Split
+
+### Main Rollout
+
+- write this plan document
+- refactor `scripts\run_from_config.py`
+- integrate new export layout and figure calls
+
+### Worker A
+
+- improve `visualization\norm_preview.py`
+- harden `visualization\oplsda_plot.py` for batch S-plot export
+
+### Worker B
+
+- add smoke-style tests for new folder structure and output selection
+
+## Future Follow-Ups
+
+Potential V2 items:
+
+- `--report-profile publication|full`
+- HTML summary index
+- optional interactive export bundle
+- report manifest JSON for downstream automation

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import warnings
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping
@@ -41,27 +42,22 @@ from core.input_resolver import (  # noqa: E402
 from core.pipeline import MetaboAnalystPipeline  # noqa: E402
 from core.sample_interface import identify_sample_columns  # noqa: E402
 from core.sample_info import read_sample_info_sheet, build_aligned_factors, extract_subject_ids  # noqa: E402
+from analysis.outlier import run_outlier_detection  # noqa: E402
+from analysis.random_forest import run_random_forest  # noqa: E402
+from analysis.roc import run_roc_analysis  # noqa: E402
 from ms_core.analysis.pca import run_pca  # noqa: E402
 from ms_core.analysis.anova import run_anova  # noqa: E402
 from ms_core.analysis.univariate import volcano_analysis  # noqa: E402
-from ms_core.visualization.pca_plot import plot_pca_score, plot_pca_scree, plot_pca_loading  # noqa: E402
-from ms_core.visualization.boxplot import plot_sample_boxplot  # noqa: E402
-from ms_core.visualization.density_plot import plot_density  # noqa: E402
+from ms_core.visualization.pca_plot import plot_pca_score  # noqa: E402
 from ms_core.visualization.anova_plot import plot_anova_importance, plot_feature_boxplot  # noqa: E402
-from visualization.oplsda_plot import plot_oplsda_score_interactive  # noqa: E402
-from visualization.pca_plot import plot_pca_score_interactive  # noqa: E402
-from visualization.plsda_plot import plot_plsda_score_interactive  # noqa: E402
-from visualization.volcano_plot import plot_volcano_interactive  # noqa: E402
+from visualization.heatmap import plot_heatmap  # noqa: E402
+from visualization.norm_preview import plot_norm_comparison  # noqa: E402
+from visualization.oplsda_plot import plot_oplsda_splot  # noqa: E402
+from visualization.outlier_plot import plot_dmodx, plot_outlier_score  # noqa: E402
+from visualization.rf_plot import plot_confusion_matrix, plot_rf_importance  # noqa: E402
+from visualization.roc_plot import plot_auc_ranking, plot_roc_curves  # noqa: E402
 
 warnings.filterwarnings("ignore")
-
-try:
-    import plotly.io as pio  # noqa: E402
-
-    HAS_PLOTLY = True
-except ImportError:
-    pio = None
-    HAS_PLOTLY = False
 
 TRUE_FILL = PatternFill(fill_type="solid", start_color="C6EFCE", end_color="C6EFCE")
 FALSE_FILL = PatternFill(fill_type="solid", start_color="FCE4D6", end_color="FCE4D6")
@@ -73,15 +69,36 @@ REDUNDANT_EXPORT_COLUMNS = {
     "pvalue_raw",
     "significance_pvalue",
 }
+REPORT_SUBDIRS = {
+    "qc": "01_QC_and_Preprocessing",
+    "global": "02_Global_Profiling",
+    "feature": "03_Feature_Selection",
+    "validation": "04_Biomarker_Validation",
+    "supplementary": "05_Supplementary",
+}
 
 
-def _save_plotly_html(fig: Any, path: str) -> bool:
-    """Persist a Plotly figure as a standalone HTML document when available."""
-    if fig is None or not HAS_PLOTLY or pio is None:
-        return False
-    html = pio.to_html(fig, include_plotlyjs="cdn", full_html=True)
-    Path(path).write_text(html, encoding="utf-8")
-    return True
+def _ensure_report_dirs(output_dir: str) -> dict[str, Path]:
+    """Create publication-oriented report subdirectories under the output root."""
+    root = Path(output_dir)
+    report_dirs: dict[str, Path] = {}
+    for key, name in REPORT_SUBDIRS.items():
+        path = root / name
+        path.mkdir(parents=True, exist_ok=True)
+        report_dirs[key] = path
+    return report_dirs
+
+
+def _save_figure(fig: Any, path: Path) -> None:
+    """Save a matplotlib-compatible figure and close it."""
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _iter_output_files(output_dir: str) -> Iterable[Path]:
+    """Yield every file under the output directory in stable relative order."""
+    root = Path(output_dir)
+    yield from sorted((path for path in root.rglob("*") if path.is_file()), key=lambda path: str(path.relative_to(root)))
 
 
 # ── Config loader ─────────────────────────────────────────
@@ -112,6 +129,19 @@ def parse_pair_config(
     return result
 
 
+def unique_group_pairs(parsed_pairs: list[tuple[str, str, bool]]) -> list[tuple[str, str]]:
+    """Return de-duplicated ordered group pairs while ignoring paired-mode metadata."""
+    seen: set[tuple[str, str]] = set()
+    unique_pairs: list[tuple[str, str]] = []
+    for group1, group2, _paired in parsed_pairs:
+        pair = (str(group1), str(group2))
+        if pair in seen:
+            continue
+        seen.add(pair)
+        unique_pairs.append(pair)
+    return unique_pairs
+
+
 def resolve_volcano_test_mode(volcano_cfg: Mapping[str, Any]) -> tuple[str, bool, bool]:
     """Return (test_key, equal_var, nonpar) for volcano analysis."""
     test_key = str(
@@ -131,6 +161,17 @@ def resolve_volcano_parametric_equal_var(volcano_cfg: Mapping[str, Any]) -> bool
 def resolve_top_vip(plsda_cfg: Mapping[str, Any]) -> int:
     """Return the configured VIP count while keeping a sane positive lower bound."""
     return max(1, int(plsda_cfg.get("top_vip", 15)))
+
+
+def resolve_volcano_fc_threshold(volcano_cfg: Mapping[str, Any]) -> tuple[float, float | None]:
+    """Return volcano FC thresholds while supporting legacy log2-only configs."""
+    fc_thresh = volcano_cfg.get("fc_thresh")
+    log2_fc_thresh = volcano_cfg.get("log2_fc_thresh")
+    if fc_thresh is None and log2_fc_thresh is None:
+        return 2.0, None
+    if fc_thresh is None:
+        return float(2 ** float(log2_fc_thresh)), float(log2_fc_thresh)
+    return float(fc_thresh), None if log2_fc_thresh is None else float(log2_fc_thresh)
 
 
 # ── Data loaders ──────────────────────────────────────────
@@ -286,6 +327,28 @@ def compose_output_suffix(
 
     ts = timestamp or datetime.now().strftime("%Y%m%d_%H%M%S")
     return f"{base}_{ts}" if base else f"_{ts}"
+
+
+def _select_heatmap_matrix(
+    df: pd.DataFrame,
+    anova_df: pd.DataFrame,
+    *,
+    max_features: int,
+) -> pd.DataFrame:
+    """Choose a stable subset for publication heatmap export."""
+    feature_cap = max(1, min(int(max_features), 50))
+    ranked = anova_df.sort_values("pvalue_adj").copy()
+    if "significant" in ranked.columns:
+        significant_mask = ranked["significant"].fillna(False).astype(bool)
+        significant = ranked.loc[significant_mask]
+    else:
+        significant = ranked.iloc[0:0]
+    feature_rows = significant if not significant.empty else ranked
+    feature_names = [feat for feat in feature_rows["Feature"].astype(str).tolist() if feat in df.columns]
+    selected = feature_names[:feature_cap]
+    if selected:
+        return df.loc[:, selected].copy()
+    return df.copy()
 
 
 # ── Significant features Excel export ────────────────────
@@ -493,6 +556,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     cfg["output"]["suffix"] = resolved_suffix
     output_dir = os.path.join(results_root, input_stem + resolved_suffix)
     os.makedirs(output_dir, exist_ok=True)
+    report_dirs = _ensure_report_dirs(output_dir)
 
     # ── Build SpecNorm factors if needed ──────────────────
     factors = None
@@ -578,6 +642,16 @@ def run_analysis(cfg: dict) -> dict[str, str]:
         (pipeline.processed_labels if pipeline.processed_labels is not None else labels).copy(),
         included_groups,
     )
+    pre_norm_matrix, _ = _finalize_analysis_matrix(
+        pipeline.steps["filtered"].copy(),
+        (pipeline.processed_labels if pipeline.processed_labels is not None else labels).copy(),
+        included_groups,
+    )
+    pre_norm_matrix = pre_norm_matrix.reindex(index=processed.index, columns=processed.columns)
+
+    raw_volcano_pairs = parse_pair_config(cfg["groups"].get("volcano_pairs", []))
+    raw_oplsda_pairs = parse_pair_config(cfg["groups"].get("oplsda_pairs", []))
+    report_pairs = unique_group_pairs(raw_volcano_pairs or raw_oplsda_pairs)
 
     print(f"  Final: {processed.shape[0]} samples x {processed.shape[1]} features")
     print(f"  Groups: {dict(final_labels.value_counts())}")
@@ -606,6 +680,15 @@ def run_analysis(cfg: dict) -> dict[str, str]:
         f.write(dump_yaml(cfg, include_runtime=False))
     print(f"  Saved to {output_dir}")
 
+    # ── QC / preprocessing report ────────────────────────
+    print("\n" + "=" * 60)
+    print("Generating QC and preprocessing report...")
+
+    fig = plt.figure(figsize=(12, 8))
+    plot_norm_comparison(pre_norm_matrix, processed, final_labels, fig=fig)
+    _save_figure(fig, report_dirs["qc"] / "normalization_comparison.png")
+    print(f"  Saved {REPORT_SUBDIRS['qc']}\\normalization_comparison.png")
+
     # ── PCA ───────────────────────────────────────────────
     print("\n" + "=" * 60)
     print("Running PCA...")
@@ -617,24 +700,8 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
     fig = plt.figure(figsize=(10, 8))
     plot_pca_score(pca_result, pc_x=0, pc_y=1, fig=fig)
-    fig.savefig(os.path.join(output_dir, "pca_score_plot.png"), dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    if _save_plotly_html(
-        plot_pca_score_interactive(pca_result, pc_x=0, pc_y=1),
-        os.path.join(output_dir, "pca_score_plot.html"),
-    ):
-        print("  Saved pca_score_plot.html")
-
-    fig = plt.figure(figsize=(8, 5))
-    plot_pca_scree(pca_result, fig=fig)
-    fig.savefig(os.path.join(output_dir, "pca_scree_plot.png"), dpi=150, bbox_inches="tight")
-    plt.close(fig)
-
-    fig = plt.figure(figsize=(10, 6))
-    plot_pca_loading(pca_result, fig=fig)
-    fig.savefig(os.path.join(output_dir, "pca_loading_plot.png"), dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    print("  Saved PCA plots (score, scree, loading)")
+    _save_figure(fig, report_dirs["qc"] / "pca_score_plot.png")
+    print(f"  Saved {REPORT_SUBDIRS['qc']}\\pca_score_plot.png")
 
     # ── ANOVA ─────────────────────────────────────────────
     print("\n" + "=" * 60)
@@ -670,21 +737,34 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
     fig = plt.figure(figsize=(10, 8))
     plot_anova_importance(anova_result, top_n=25, fig=fig)
-    fig.savefig(os.path.join(output_dir, "anova_importance.png"), dpi=150, bbox_inches="tight")
-    plt.close(fig)
+    _save_figure(fig, report_dirs["feature"] / "anova_importance.png")
 
     anova_ranked = anova_result.result_df.sort_values("pvalue_adj").copy()
     anova_feature_pool = anova_ranked["Feature"].tolist()
     sig_feature_pool = anova_ranked.loc[anova_ranked["significant"], "Feature"].tolist()
-    anova_pairs = parse_pair_config(cfg["groups"].get("volcano_pairs", []))
-    saved_anova_boxplots = 0
-    seen_anova_pairs = set()
-    for g1, g2, _paired in anova_pairs:
-        pair_key = (g1, g2)
-        if pair_key in seen_anova_pairs:
-            continue
-        seen_anova_pairs.add(pair_key)
+    heatmap_cfg = analysis_cfg.get("heatmap", {})
+    heatmap_df = _select_heatmap_matrix(
+        processed,
+        anova_ranked,
+        max_features=int(heatmap_cfg.get("max_features", 50)),
+    )
+    if not heatmap_df.empty:
+        heatmap_fig = plot_heatmap(
+            heatmap_df,
+            final_labels.reindex(heatmap_df.index),
+            method=str(heatmap_cfg.get("method", "ward")),
+            metric=str(heatmap_cfg.get("metric", "euclidean")),
+            scale=heatmap_cfg.get("scale", "row"),
+            max_features=min(int(heatmap_cfg.get("max_features", 50)), 50),
+            top_by=str(heatmap_cfg.get("top_by", "var")),
+        )
+        _save_figure(heatmap_fig, report_dirs["global"] / "heatmap_top50.png")
+        print(f"  Saved {REPORT_SUBDIRS['global']}\\heatmap_top50.png")
 
+    anova_pairs = report_pairs
+    saved_anova_boxplots = 0
+    anova_boxplot_top_n = 10
+    for g1, g2 in anova_pairs:
         pair_mask = final_labels.isin([g1, g2])
         pair_data = anova_matrix.loc[pair_mask]
         pair_labels = final_labels.loc[pair_mask]
@@ -700,24 +780,22 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             candidate_features,
             key=lambda feat: abs(pair_means.loc[g1, feat] - pair_means.loc[g2, feat]),
             reverse=True,
-        )[:5]
+        )[:anova_boxplot_top_n]
 
         for i, feat in enumerate(ranked_features, start=1):
             fig = plt.figure(figsize=(7, 5))
             plot_feature_boxplot(pair_data, pair_labels, feat, fig=fig)
-            fig.savefig(
-                os.path.join(output_dir, f"anova_boxplot_{g1}_vs_{g2}_top{i}.png"),
-                dpi=150,
-                bbox_inches="tight",
+            _save_figure(
+                fig,
+                report_dirs["supplementary"] / f"anova_boxplot_{g1}_vs_{g2}_top{i}.png",
             )
-            plt.close(fig)
             saved_anova_boxplots += 1
-    print(f"  Saved ANOVA results + {saved_anova_boxplots} pairwise boxplots")
+    print(f"  Saved {REPORT_SUBDIRS['feature']}\\anova_importance.png")
+    print(f"  Saved {saved_anova_boxplots} supplementary ANOVA boxplots")
 
     # ── PLS-DA + VIP (pairwise, 2-group) ─────────────────────
     plsda_cfg = analysis_cfg.get("plsda", {})
-    raw_plsda_pairs = cfg["groups"].get("oplsda_pairs", [])  # reuse OPLS-DA pairs
-    plsda_pairs = parse_pair_config(raw_plsda_pairs)
+    plsda_pairs = raw_oplsda_pairs
     if plsda_cfg and plsda_pairs:
         print("\n" + "=" * 60)
         print("Running pairwise PLS-DA + VIP...")
@@ -736,18 +814,8 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             all_plsda_result = run_plsda(processed, final_labels, n_components=n_comp)
             fig = plt.figure(figsize=(8, 6))
             plot_plsda_score(all_plsda_result, fig=fig)
-            fig.savefig(
-                os.path.join(output_dir, "plsda_score_all_groups.png"),
-                dpi=150,
-                bbox_inches="tight",
-            )
-            plt.close(fig)
-            print("  Saved plsda_score_all_groups.png")
-            if _save_plotly_html(
-                plot_plsda_score_interactive(all_plsda_result),
-                os.path.join(output_dir, "plsda_score_all_groups.html"),
-            ):
-                print("  Saved plsda_score_all_groups.html")
+            _save_figure(fig, report_dirs["supplementary"] / "plsda_score_all_groups.png")
+            print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\plsda_score_all_groups.png")
         except Exception as e:
             print(f"  All-group PLS-DA error: {e}")
 
@@ -767,27 +835,11 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 vip_df.insert(0, "Rank", range(1, len(vip_df) + 1))
                 _excel_sheets[f"VIP_{g1}_vs_{g2}"] = vip_df
 
-                fig = plt.figure(figsize=(8, 6))
-                plot_plsda_score(plsda_result, fig=fig)
-                fig.savefig(
-                    os.path.join(output_dir, f"plsda_score_{g1}_vs_{g2}.png"),
-                    dpi=150,
-                    bbox_inches="tight",
-                )
-                plt.close(fig)
-                if _save_plotly_html(
-                    plot_plsda_score_interactive(plsda_result),
-                    os.path.join(output_dir, f"plsda_score_{g1}_vs_{g2}.html"),
-                ):
-                    print(f"    Saved plsda_score_{g1}_vs_{g2}.html")
-
                 fig = plt.figure(figsize=(10, max(6, top_vip * 0.32)))
                 plot_vip(plsda_result, top_n=top_vip,
                          data=pair_data, labels=pair_labels, fig=fig)
-                fig.savefig(os.path.join(output_dir, f"plsda_vip_{g1}_vs_{g2}.png"),
-                            dpi=150, bbox_inches="tight")
-                plt.close(fig)
-                print(f"    Saved plsda_vip_{g1}_vs_{g2}.png")
+                _save_figure(fig, report_dirs["feature"] / f"plsda_vip_{g1}_vs_{g2}.png")
+                print(f"    Saved {REPORT_SUBDIRS['feature']}\\plsda_vip_{g1}_vs_{g2}.png")
             except Exception as e:
                 print(f"    Error: {e}")
 
@@ -824,16 +876,14 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 # Score plot
                 fig = plt.figure(figsize=(8, 6))
                 plot_oplsda_score(oplsda_result, fig=fig)
-                fig.savefig(os.path.join(output_dir, f"oplsda_score_{g1}_vs_{g2}.png"),
-                            dpi=150, bbox_inches="tight")
-                plt.close(fig)
-                if _save_plotly_html(
-                    plot_oplsda_score_interactive(oplsda_result),
-                    os.path.join(output_dir, f"oplsda_score_{g1}_vs_{g2}.html"),
-                ):
-                    print(f"    Saved oplsda_score_{g1}_vs_{g2}.html")
+                _save_figure(fig, report_dirs["feature"] / f"oplsda_score_{g1}_vs_{g2}.png")
 
-                print("    Saved score plot")
+                fig = plt.figure(figsize=(8, 6))
+                plot_oplsda_splot(oplsda_result, top_n=10, fig=fig)
+                _save_figure(fig, report_dirs["feature"] / f"oplsda_splot_{g1}_vs_{g2}.png")
+
+                print(f"    Saved {REPORT_SUBDIRS['feature']}\\oplsda_score_{g1}_vs_{g2}.png")
+                print(f"    Saved {REPORT_SUBDIRS['feature']}\\oplsda_splot_{g1}_vs_{g2}.png")
             except Exception as e:
                 print(f"    Error: {e}")
 
@@ -843,9 +893,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     from visualization.volcano_plot import plot_volcano
 
     vol_cfg = analysis_cfg["volcano"]
-    raw_pairs = cfg["groups"].get("volcano_pairs", [])
-    volcano_pairs = parse_pair_config(raw_pairs)
+    volcano_pairs = raw_volcano_pairs
     volcano_test_key, volcano_equal_var, volcano_nonpar = resolve_volcano_test_mode(vol_cfg)
+    volcano_fc_thresh, volcano_log2_fc_thresh = resolve_volcano_fc_threshold(vol_cfg)
     paired_resolution_cfg = cfg["groups"].get("paired_resolution")
 
     # Extract subject IDs if any pair is paired
@@ -867,8 +917,8 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             vresult = volcano_analysis(
                 volcano_matrix, final_labels,
                 group1=g1, group2=g2,
-                fc_thresh=vol_cfg["fc_thresh"],
-                log2_fc_thresh=vol_cfg.get("log2_fc_thresh"),
+                fc_thresh=volcano_fc_thresh,
+                log2_fc_thresh=volcano_log2_fc_thresh,
                 p_thresh=vol_cfg["p_thresh"],
                 equal_var=volcano_equal_var,
                 nonpar=volcano_nonpar,
@@ -924,34 +974,123 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 _excel_sheets[f"Volcano_{g1}_vs_{g2}"] = vol_sig
             fig = plt.figure(figsize=(10, 8))
             plot_volcano(vresult, fig=fig)
-            fig.savefig(os.path.join(output_dir, f"volcano_{g1}_vs_{g2}.png"),
-                        dpi=150, bbox_inches="tight")
-            plt.close(fig)
-            if _save_plotly_html(
-                plot_volcano_interactive(vresult),
-                os.path.join(output_dir, f"volcano_{g1}_vs_{g2}.html"),
-            ):
-                print(f"    Saved volcano_{g1}_vs_{g2}.html")
+            _save_figure(fig, report_dirs["feature"] / f"volcano_{g1}_vs_{g2}.png")
+            print(f"    Saved {REPORT_SUBDIRS['feature']}\\volcano_{g1}_vs_{g2}.png")
         except Exception as e:
             print(f"    Error: {e}")
 
-    # ── Sample overview ───────────────────────────────────
+    # ── ROC / biomarker validation ───────────────────────
     print("\n" + "=" * 60)
-    print("Generating sample-level overview plots...")
-    fig = plt.figure(figsize=(16, 6))
-    plot_sample_boxplot(processed, final_labels,
-                        title="Sample Distribution (after processing)", fig=fig)
-    fig.savefig(os.path.join(output_dir, "sample_boxplot.png"),
-                dpi=150, bbox_inches="tight")
-    plt.close(fig)
+    print("Running biomarker validation plots...")
+    roc_cfg = analysis_cfg.get("roc", {})
+    roc_top_n = int(roc_cfg.get("top_n", 10))
+    roc_multi_feature = bool(roc_cfg.get("multi_feature", True))
+    roc_cv_folds = int(roc_cfg.get("cv_folds", 5))
+    for g1, g2 in report_pairs:
+        print(f"  ROC {g1} vs {g2}...")
+        try:
+            pair_mask = final_labels.isin([g1, g2])
+            pair_data = processed.loc[pair_mask]
+            pair_labels = final_labels.loc[pair_mask]
+            if pair_data.empty or pair_labels.nunique() < 2:
+                print("    Skipped (not enough pairwise samples)")
+                continue
 
-    fig = plt.figure(figsize=(10, 6))
-    plot_density(processed, final_labels,
-                 title="Density Plot (after processing)", fig=fig)
-    fig.savefig(os.path.join(output_dir, "density_plot.png"),
-                dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    print("  Saved sample_boxplot.png + density_plot.png")
+            roc_result = run_roc_analysis(
+                pair_data,
+                pair_labels,
+                group1=g1,
+                group2=g2,
+                top_n=roc_top_n,
+                multi_feature=roc_multi_feature,
+                cv_folds=roc_cv_folds,
+            )
+            roc_result.summary_df.to_csv(
+                os.path.join(output_dir, f"roc_{g1}_vs_{g2}.csv"),
+                index=False,
+            )
+
+            fig = plt.figure(figsize=(8, 6))
+            plot_roc_curves(roc_result, fig=fig)
+            _save_figure(fig, report_dirs["validation"] / f"roc_{g1}_vs_{g2}.png")
+
+            fig = plt.figure(figsize=(8, 6))
+            plot_auc_ranking(roc_result, fig=fig)
+            _save_figure(fig, report_dirs["validation"] / f"auc_ranking_{g1}_vs_{g2}.png")
+
+            print(f"    Saved {REPORT_SUBDIRS['validation']}\\roc_{g1}_vs_{g2}.png")
+            print(f"    Saved {REPORT_SUBDIRS['validation']}\\auc_ranking_{g1}_vs_{g2}.png")
+        except Exception as e:
+            print(f"    Error: {e}")
+
+    # ── Supplementary: outlier detection ─────────────────
+    print("\n" + "=" * 60)
+    print("Generating supplementary outlier plots...")
+    outlier_cfg = analysis_cfg.get("outlier", {})
+    try:
+        outlier_result = run_outlier_detection(
+            processed,
+            n_components=int(outlier_cfg.get("n_components", 2)),
+            alpha=float(outlier_cfg.get("alpha", 0.05)),
+        )
+        outlier_result.get_outlier_df().to_csv(
+            os.path.join(output_dir, "outlier_results.csv"),
+            index=False,
+        )
+
+        fig = plt.figure(figsize=(8, 6))
+        plot_outlier_score(outlier_result, labels=final_labels, fig=fig)
+        _save_figure(fig, report_dirs["supplementary"] / "outlier_t2.png")
+
+        fig = plt.figure(figsize=(8, 6))
+        plot_dmodx(outlier_result, labels=final_labels, fig=fig)
+        _save_figure(fig, report_dirs["supplementary"] / "outlier_dmodx.png")
+        print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_t2.png")
+        print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_dmodx.png")
+    except Exception as e:
+        print(f"  Outlier export error: {e}")
+
+    # ── Supplementary: random forest ─────────────────────
+    print("\n" + "=" * 60)
+    print("Generating supplementary Random Forest plots...")
+    rf_cfg = analysis_cfg.get("random_forest", {})
+    rf_trees = int(rf_cfg.get("n_trees", 500))
+    rf_cv_folds = int(rf_cfg.get("cv_folds", 5))
+    rf_top_n = int(rf_cfg.get("top_n", 25))
+    for g1, g2 in report_pairs:
+        print(f"  RF {g1} vs {g2}...")
+        try:
+            pair_mask = final_labels.isin([g1, g2])
+            pair_data = processed.loc[pair_mask]
+            pair_labels = final_labels.loc[pair_mask]
+            if pair_data.empty or pair_labels.nunique() < 2:
+                print("    Skipped (not enough pairwise samples)")
+                continue
+
+            rf_result = run_random_forest(
+                pair_data,
+                pair_labels,
+                n_trees=rf_trees,
+                cv_folds=rf_cv_folds,
+                top_n=rf_top_n,
+            )
+            rf_result.feature_importance.to_csv(
+                os.path.join(output_dir, f"rf_importance_{g1}_vs_{g2}.csv"),
+                index=False,
+            )
+
+            fig = plt.figure(figsize=(8, 6))
+            plot_rf_importance(rf_result, top_n=rf_top_n, fig=fig)
+            _save_figure(fig, report_dirs["supplementary"] / f"rf_importance_{g1}_vs_{g2}.png")
+
+            fig = plt.figure(figsize=(6, 5))
+            plot_confusion_matrix(rf_result, fig=fig)
+            _save_figure(fig, report_dirs["supplementary"] / f"rf_confusion_matrix_{g1}_vs_{g2}.png")
+
+            print(f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_importance_{g1}_vs_{g2}.png")
+            print(f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_confusion_matrix_{g1}_vs_{g2}.png")
+        except Exception as e:
+            print(f"    Error: {e}")
 
     if paired_resolution_audit_rows:
         audit_path = os.path.join(output_dir, "paired_resolution_audit.csv")
@@ -974,9 +1113,11 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     print("ANALYSIS COMPLETE")
     print(f"All outputs saved to: {output_dir}")
     print("\nGenerated files:")
-    for f in sorted(os.listdir(output_dir)):
-        size = os.path.getsize(os.path.join(output_dir, f))
-        print(f"  {f:40s} ({size / 1024:.0f} KB)")
+    output_root = Path(output_dir)
+    for path in _iter_output_files(output_dir):
+        rel = str(path.relative_to(output_root))
+        size = path.stat().st_size
+        print(f"  {rel:70s} ({size / 1024:.0f} KB)")
     return {"output_dir": output_dir}
 
 

--- a/skills/run-cmd-contract/SKILL.md
+++ b/skills/run-cmd-contract/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: run-cmd-contract
+description: Use when the user asks to execute this repository's pipeline with an input workbook and a YAML config in natural language, especially phrases like `用這個 xlsx 跑這個 yaml`, `幫我用 <input.xlsx> 跑 <config.yaml>`, or `拿這個 xlsx 跑那個 yaml`.
+---
+
+# Run CMD Contract
+
+## Overview
+
+This repository has a preferred natural-language execution contract:
+
+- spreadsheet path first
+- yaml config path second
+- mapped directly to `run.cmd`
+
+When the user phrases a request like:
+
+- `用這個 xlsx 跑這個 yaml`
+- `幫我用 <input.xlsx> 跑 <config.yaml>`
+- `拿這個 xlsx 跑那個 yaml`
+
+do not re-discover the CLI entry point. Treat it as a direct request to execute the repository wrapper.
+
+## Default Mapping
+
+Use:
+
+```powershell
+run.cmd "<input.xlsx>" "<config.yaml>"
+```
+
+If the user also requests a custom suffix:
+
+```powershell
+run.cmd "<input.xlsx>" "<config.yaml>" -Suffix "_custom"
+```
+
+## Why This Contract Exists
+
+- It mirrors the way humans naturally describe the task in chat.
+- It is more stable on Windows than ad-hoc raw argument forwarding.
+- It keeps one-off runs out of YAML editing.
+
+## Preferred Command Order
+
+1. First choice:
+
+```powershell
+run.cmd "<input.xlsx>" "<config.yaml>"
+```
+
+2. If wrapper debugging is required:
+
+```powershell
+scripts\run_pipeline.cmd -Config <config.yaml> -Input "<input.xlsx>" [-Suffix "_tag"]
+```
+
+3. Only if direct Python debugging is required:
+
+```powershell
+uv run python scripts\run_from_config.py <config.yaml> --input "<input.xlsx>" [--suffix "_tag"]
+```
+
+## Rules
+
+1. If the user clearly gives an input workbook path and a YAML config path, do not spend time re-finding the CLI interface.
+2. Prefer wrapper-level overrides instead of editing YAML for one-off runs.
+3. Report the exact config path, exact input path, and final output directory after the run.
+4. If the wrapper is missing or broken, say so explicitly and fall back to `scripts\run_pipeline.cmd` or `scripts\run_from_config.py`.
+
+## Output Expectations
+
+After execution, report:
+
+- config used
+- input used
+- output directory
+- key high-level metrics from stdout

--- a/skills/run-cmd-contract/agents/openai.yaml
+++ b/skills/run-cmd-contract/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run CMD Contract"
+  short_description: "Map natural-language xlsx + yaml execution requests to run.cmd"
+  default_prompt: "Use $run-cmd-contract to execute this repository's pipeline when the user phrases the task as input workbook plus YAML config."

--- a/tests/test_publication_batch_report_smoke.py
+++ b/tests/test_publication_batch_report_smoke.py
@@ -1,0 +1,396 @@
+"""Smoke coverage for the publication-oriented batch report layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import ms_core.analysis.oplsda as ms_oplsda_mod
+import ms_core.analysis.plsda as ms_plsda_mod
+import ms_core.visualization.oplsda_plot as ms_oplsda_plot_mod
+import ms_core.visualization.plsda_plot as ms_plsda_plot_mod
+import ms_core.visualization.vip_plot as ms_vip_plot_mod
+import scripts.run_from_config as run_mod
+import visualization.volcano_plot as volcano_plot_mod
+
+pytestmark = pytest.mark.integration
+
+
+class _DummyPipeline:
+    def __init__(self, data: pd.DataFrame, labels: pd.Series, feature_metadata: pd.DataFrame) -> None:
+        self._data = data
+        self._labels = labels
+        self._feature_metadata = feature_metadata
+        self.log = ["fake pipeline"]
+        self.steps: dict[str, pd.DataFrame] = {}
+        self.step_feature_metadata: dict[str, pd.DataFrame] = {}
+        self.processed: pd.DataFrame | None = None
+        self.processed_labels: pd.Series | None = None
+        self.processed_feature_metadata: pd.DataFrame | None = None
+
+    def run_pipeline(self, **kwargs) -> pd.DataFrame:
+        self.processed = self._data.copy()
+        self.processed_labels = self._labels.copy()
+        self.processed_feature_metadata = self._feature_metadata.copy()
+        self.steps = {
+            "filtered": self._data.copy(),
+            "transformed": self._data.copy(),
+            "row_normed": self._data.copy(),
+        }
+        self.step_feature_metadata = {"qc_rsd": pd.DataFrame()}
+        return self.processed
+
+
+class _DummyPCAResult:
+    def __init__(self) -> None:
+        self.explained_variance_ratio = np.array([0.58, 0.27, 0.15], dtype=float)
+
+
+class _DummyANOVAResult:
+    def __init__(self, features: list[str]) -> None:
+        self.method_key = "anova"
+        self.p_thresh = 0.05
+        self.n_significant = 2
+        self.result_df = pd.DataFrame(
+            {
+                "Feature": features,
+                "pvalue": [0.001, 0.02, 0.50],
+                "pvalue_adj": [0.003, 0.04, 0.60],
+                "neg_log10p": [3.0, 1.7, 0.2],
+                "significant": [True, True, False],
+                "is_Presence_Absence_Marker": [False, False, True],
+            }
+        )
+
+
+class _DummyPLSDAResult:
+    def __init__(self, features: list[str], groups: list[str]) -> None:
+        self.explained_variance = np.array([0.64, 0.23], dtype=float)
+        self.q2 = 0.71
+        self.vips = np.array([1.5, 1.1, 0.9], dtype=float)
+        self.class_names = np.array(groups, dtype=object)
+        self._features = features
+
+    def get_vip_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Feature": self._features,
+                "VIP": [1.5, 1.1, 0.9],
+                "is_Presence_Absence_Marker": [False, False, True],
+            }
+        )
+
+
+class _DummyOPLSDAResult:
+    def __init__(self, features: list[str], groups: list[str]) -> None:
+        self.r2x = 0.51
+        self.r2y = 0.63
+        self.q2 = 0.44
+        self.backend = "pyopls"
+        self.class_names = np.array(groups, dtype=object)
+        self._features = features
+
+    def get_score_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Sample": ["S1", "S2", "S3", "S4"],
+                "Group": ["Exposure", "Exposure", "Normal", "Normal"],
+                "T_predictive": [0.9, 0.7, -0.8, -0.6],
+                "T_orthogonal": [0.2, -0.1, 0.3, 0.1],
+            }
+        )
+
+    def get_importance_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Feature": self._features,
+                "Loading": [0.8, -0.4, 0.2],
+                "Importance": [0.8, 0.4, 0.2],
+                "is_Presence_Absence_Marker": [False, False, True],
+            }
+        )
+
+
+class _DummyVolcanoResult:
+    def __init__(self, features: list[str], group1: str, group2: str) -> None:
+        self.group1 = group1
+        self.group2 = group2
+        self.fc_thresh = 2.0
+        self.log2_fc_thresh = 1.0
+        self.p_thresh = 0.05
+        self.use_fdr = True
+        self.fdr_method = "fdr_bh"
+        self.test_label = "Welch's t"
+        self.n_significant = 2
+        self.n_up = 1
+        self.n_down = 1
+        self.n_pairs = 0
+        self.resolution_overrides_applied: list[dict[str, str]] = []
+        self.resolution_warnings: list[str] = []
+        self.result_df = pd.DataFrame(
+            {
+                "Feature": features,
+                "log2FC": [1.4, -1.2, 0.1],
+                "pvalue": [0.001, 0.02, 0.80],
+                "pvalue_adj": [0.002, 0.03, 0.90],
+                "significant": [True, True, False],
+                "is_Presence_Absence_Marker": [False, False, True],
+            }
+        )
+        self.significant = self.result_df.loc[self.result_df["significant"]].copy()
+
+
+class _DummyOutlierResult:
+    def __init__(self, sample_names: list[str]) -> None:
+        self.sample_names = sample_names
+
+    def get_outlier_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Sample": self.sample_names,
+                "T2": np.linspace(0.2, 1.2, len(self.sample_names)),
+                "T2_Outlier": [False] * len(self.sample_names),
+                "DModX": np.linspace(0.1, 0.6, len(self.sample_names)),
+                "DModX_Outlier": [False] * len(self.sample_names),
+                "Any_Outlier": [False] * len(self.sample_names),
+            }
+        )
+
+
+def _make_roc_result() -> SimpleNamespace:
+    summary = pd.DataFrame(
+        {
+            "Feature": ["F1", "F2"],
+            "AUC": [0.91, 0.82],
+            "Optimal_Cutoff": [0.5, 0.5],
+            "Sensitivity": [0.88, 0.80],
+            "Specificity": [0.84, 0.76],
+        }
+    )
+    return SimpleNamespace(
+        single_rocs=[],
+        multi_fpr=np.array([0.0, 0.3, 1.0]),
+        multi_tpr=np.array([0.0, 0.8, 1.0]),
+        multi_auc=0.89,
+        summary_df=summary,
+        single_cv_folds_used=2,
+        multi_cv_folds_used=2,
+    )
+
+
+def _make_rf_result(features: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        feature_importance=pd.DataFrame(
+            {
+                "Feature": features,
+                "Importance": [0.6, 0.3, 0.1],
+            }
+        ),
+        oob_accuracy=0.83,
+        cv_accuracy=0.79,
+        cv_std=0.05,
+        confusion_mat=np.array([[2, 0], [1, 1]]),
+        class_names=["Exposure", "Normal"],
+    )
+
+
+def _stub_plot(label: str):
+    def _plot(*args, fig=None, **kwargs):
+        if fig is None:
+            fig = plt.figure(figsize=(4, 3))
+        fig.clf()
+        ax = fig.add_subplot(111)
+        ax.text(0.5, 0.5, label, ha="center", va="center", fontsize=11)
+        ax.set_axis_off()
+        ax.set_title(label)
+        return fig
+
+    return _plot
+
+
+def _install_smoke_stubs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
+    sample_names = [
+        "Exposure_A",
+        "Exposure_B",
+        "Normal_A",
+        "Normal_B",
+        "Control_A",
+        "Control_B",
+    ]
+    features = ["F1", "F2", "F3"]
+    data = pd.DataFrame(
+        {
+            "F1": [10.0, 11.0, 20.0, 21.0, 30.0, 31.0],
+            "F2": [5.0, 4.5, 3.0, 3.5, 2.0, 2.5],
+            "F3": [1.0, 1.2, 1.5, 1.7, 1.9, 2.1],
+        },
+        index=sample_names,
+    )
+    labels = pd.Series(
+        ["Exposure", "Exposure", "Normal", "Normal", "Control", "Control"],
+        index=sample_names,
+        name="Group",
+    )
+    feature_metadata = pd.DataFrame(
+        {
+            "is_Presence_Absence_Marker": [False, False, True],
+            "imputation_method": ["knn", "knn", "min"],
+        },
+        index=features,
+    )
+
+    monkeypatch.setattr(run_mod, "_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setattr(run_mod, "load_data", lambda cfg: (data.copy(), labels.copy(), feature_metadata.copy()))
+    monkeypatch.setattr(run_mod, "MetaboAnalystPipeline", _DummyPipeline)
+    monkeypatch.setattr(run_mod, "run_pca", lambda *args, **kwargs: _DummyPCAResult())
+    monkeypatch.setattr(run_mod, "run_anova", lambda *args, **kwargs: _DummyANOVAResult(features))
+    monkeypatch.setattr(
+        run_mod,
+        "volcano_analysis",
+        lambda *args, **kwargs: _DummyVolcanoResult(features, kwargs["group1"], kwargs["group2"]),
+    )
+    monkeypatch.setattr(run_mod, "run_roc_analysis", lambda *args, **kwargs: _make_roc_result())
+    monkeypatch.setattr(run_mod, "run_random_forest", lambda *args, **kwargs: _make_rf_result(features))
+    monkeypatch.setattr(run_mod, "run_outlier_detection", lambda *args, **kwargs: _DummyOutlierResult(sample_names))
+
+    monkeypatch.setattr(run_mod, "plot_norm_comparison", _stub_plot("Normalization Comparison"))
+    monkeypatch.setattr(run_mod, "plot_pca_score", _stub_plot("PCA Score Plot"))
+    monkeypatch.setattr(run_mod, "plot_anova_importance", _stub_plot("ANOVA Importance Plot"))
+    monkeypatch.setattr(run_mod, "plot_feature_boxplot", _stub_plot("ANOVA Feature Boxplot"))
+    monkeypatch.setattr(run_mod, "plot_heatmap", _stub_plot("Heatmap"))
+    monkeypatch.setattr(run_mod, "plot_oplsda_splot", _stub_plot("OPLS-DA S-Plot"))
+    monkeypatch.setattr(run_mod, "plot_outlier_score", _stub_plot("Outlier T2"))
+    monkeypatch.setattr(run_mod, "plot_dmodx", _stub_plot("Outlier DModX"))
+    monkeypatch.setattr(run_mod, "plot_roc_curves", _stub_plot("ROC Curves"))
+    monkeypatch.setattr(run_mod, "plot_auc_ranking", _stub_plot("AUC Ranking"))
+    monkeypatch.setattr(run_mod, "plot_rf_importance", _stub_plot("RF Importance"))
+    monkeypatch.setattr(run_mod, "plot_confusion_matrix", _stub_plot("RF Confusion"))
+
+    monkeypatch.setattr(ms_plsda_mod, "run_plsda", lambda *args, **kwargs: _DummyPLSDAResult(features, ["Exposure", "Normal", "Control"]))
+    monkeypatch.setattr(ms_plsda_plot_mod, "plot_plsda_score", _stub_plot("PLS-DA Score Plot"))
+    monkeypatch.setattr(ms_vip_plot_mod, "plot_vip", _stub_plot("PLS-DA VIP Plot"))
+    monkeypatch.setattr(ms_oplsda_mod, "run_oplsda", lambda *args, **kwargs: _DummyOPLSDAResult(features, ["Exposure", "Normal"]))
+    monkeypatch.setattr(ms_oplsda_plot_mod, "plot_oplsda_score", _stub_plot("OPLS-DA Score Plot"))
+    monkeypatch.setattr(volcano_plot_mod, "plot_volcano", _stub_plot("Volcano Plot"))
+
+    return data, labels, feature_metadata
+
+
+def _build_publication_config(tmp_path: Path) -> dict:
+    return {
+        "input": {
+            "file": str(tmp_path / "demo_publication.xlsx"),
+            "format": "plain",
+        },
+        "pipeline": {
+            "missing_thresh": 1.0,
+            "impute_method": "knn",
+            "qc_rsd_enabled": True,
+            "qc_rsd_threshold": 0.50,
+            "filter_method": "None",
+            "filter_cutoff": 0,
+            "row_norm": "None",
+            "transform": "Log10Norm",
+            "scaling": "ParetoNorm",
+        },
+        "groups": {
+            "include": ["Exposure", "Normal", "Control"],
+            "pair_id_pattern": r"BC\d+",
+            "volcano_pairs": [
+                {"groups": ["Exposure", "Normal"], "paired": False},
+                {"groups": ["Exposure", "Control"], "paired": False},
+                {"groups": ["Normal", "Control"], "paired": False},
+            ],
+            "oplsda_pairs": [
+                {"groups": ["Exposure", "Normal"], "paired": False},
+                {"groups": ["Exposure", "Control"], "paired": False},
+                {"groups": ["Normal", "Control"], "paired": False},
+            ],
+        },
+        "analysis": {
+            "pca": {"n_components": 3},
+            "plsda": {"n_components": 2, "top_vip": 15},
+            "anova": {"p_thresh": 0.05, "nonpar": False, "use_fdr": True, "posthoc": True},
+            "volcano": {
+                "fc_thresh": 2.0,
+                "log2_fc_thresh": 1.0,
+                "p_thresh": 0.05,
+                "use_fdr": True,
+                "parametric_test_default": "welch",
+            },
+            "heatmap": {"max_features": 50, "top_by": "var", "method": "ward", "metric": "euclidean", "scale": "row"},
+            "roc": {"top_n": 10, "multi_feature": True},
+            "outlier": {"n_components": 2, "alpha": 0.05},
+            "random_forest": {"n_trees": 500, "cv_folds": 5, "top_n": 25},
+        },
+        "output": {
+            "suffix": "_publication_smoke",
+            "auto_timestamp": False,
+        },
+    }
+
+
+def test_publication_report_smoke_layout_and_pruning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_smoke_stubs(monkeypatch, tmp_path)
+    cfg = _build_publication_config(tmp_path)
+
+    result = run_mod.run_analysis(cfg)
+
+    output_dir = Path(result["output_dir"])
+    expected_dirs = [
+        output_dir / "01_QC_and_Preprocessing",
+        output_dir / "02_Global_Profiling",
+        output_dir / "03_Feature_Selection",
+        output_dir / "04_Biomarker_Validation",
+        output_dir / "05_Supplementary",
+    ]
+    expected_files = [
+        output_dir / "config_used.yaml",
+        output_dir / "processed_data.csv",
+        output_dir / "sample_labels.csv",
+        output_dir / "feature_metadata.csv",
+        output_dir / "anova_results.csv",
+        output_dir / "roc_Exposure_vs_Normal.csv",
+        output_dir / "rf_importance_Exposure_vs_Normal.csv",
+        output_dir / "outlier_results.csv",
+        output_dir / "01_QC_and_Preprocessing" / "normalization_comparison.png",
+        output_dir / "01_QC_and_Preprocessing" / "pca_score_plot.png",
+        output_dir / "02_Global_Profiling" / "heatmap_top50.png",
+        output_dir / "03_Feature_Selection" / "oplsda_score_Exposure_vs_Normal.png",
+        output_dir / "03_Feature_Selection" / "oplsda_splot_Exposure_vs_Normal.png",
+        output_dir / "03_Feature_Selection" / "volcano_Exposure_vs_Normal.png",
+        output_dir / "03_Feature_Selection" / "plsda_vip_Exposure_vs_Normal.png",
+        output_dir / "03_Feature_Selection" / "anova_importance.png",
+        output_dir / "04_Biomarker_Validation" / "roc_Exposure_vs_Normal.png",
+        output_dir / "04_Biomarker_Validation" / "auc_ranking_Exposure_vs_Normal.png",
+        output_dir / "05_Supplementary" / "plsda_score_all_groups.png",
+        output_dir / "05_Supplementary" / "outlier_t2.png",
+        output_dir / "05_Supplementary" / "outlier_dmodx.png",
+        output_dir / "05_Supplementary" / "rf_importance_Exposure_vs_Normal.png",
+        output_dir / "05_Supplementary" / "rf_confusion_matrix_Exposure_vs_Normal.png",
+        output_dir / "05_Supplementary" / "anova_boxplot_Exposure_vs_Normal_top1.png",
+    ]
+    legacy_files = [
+        output_dir / "pca_scree_plot.png",
+        output_dir / "pca_loading_plot.png",
+        output_dir / "sample_boxplot.png",
+        output_dir / "density_plot.png",
+        output_dir / "plsda_score_Exposure_vs_Normal.png",
+        output_dir / "pca_score_plot.html",
+        output_dir / "oplsda_score_Exposure_vs_Normal.html",
+        output_dir / "volcano_Exposure_vs_Normal.html",
+    ]
+
+    for folder in expected_dirs:
+        assert folder.is_dir(), f"missing report folder: {folder}"
+
+    for file_path in expected_files:
+        assert file_path.is_file(), f"missing report file: {file_path}"
+
+    for file_path in legacy_files:
+        assert not file_path.exists(), f"legacy output should not be emitted: {file_path}"

--- a/tests/test_random_forest_njobs.py
+++ b/tests/test_random_forest_njobs.py
@@ -1,6 +1,9 @@
 """Test that METABO_N_JOBS env var controls n_jobs in RandomForestClassifier."""
 import importlib
 
+import numpy as np
+import pandas as pd
+
 
 def test_random_forest_respects_metabo_n_jobs(monkeypatch):
     """METABO_N_JOBS env var must propagate to RandomForestClassifier n_jobs."""
@@ -19,3 +22,66 @@ def test_random_forest_respects_metabo_n_jobs(monkeypatch):
     monkeypatch.setenv("METABO_N_JOBS", "1")
     importlib.reload(rf_mod)
     assert rf_mod._N_JOBS == 1
+
+
+def test_random_forest_falls_back_to_single_process_on_permission_error(monkeypatch):
+    """Permission errors in parallel backends should fall back to n_jobs=1."""
+    import analysis.random_forest as rf_mod
+
+    fit_calls: list[int] = []
+    score_calls: list[tuple[int, int]] = []
+    predict_calls: list[tuple[int, int]] = []
+
+    class DummyRF:
+        def __init__(self, *, n_estimators, oob_score, random_state, n_jobs):
+            self.n_estimators = n_estimators
+            self.oob_score = oob_score
+            self.random_state = random_state
+            self.n_jobs = n_jobs
+            self.oob_score_ = 0.91
+            self.feature_importances_ = np.array([0.7, 0.3], dtype=float)
+
+        def fit(self, X, y):
+            fit_calls.append(self.n_jobs)
+            if self.n_jobs != 1:
+                raise PermissionError(5, "denied")
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X), dtype=int)
+
+    def fake_cross_val_score(estimator, X, y, cv, scoring, n_jobs):
+        score_calls.append((estimator.n_jobs, n_jobs))
+        return np.array([0.8, 0.9], dtype=float)
+
+    def fake_cross_val_predict(estimator, X, y, cv, n_jobs):
+        predict_calls.append((estimator.n_jobs, n_jobs))
+        return np.zeros(len(y), dtype=int)
+
+    monkeypatch.setattr(rf_mod, "_N_JOBS", 2)
+    monkeypatch.setattr(rf_mod, "RandomForestClassifier", DummyRF)
+    monkeypatch.setattr(rf_mod, "cross_val_score", fake_cross_val_score)
+    monkeypatch.setattr(rf_mod, "cross_val_predict", fake_cross_val_predict)
+
+    df = pd.DataFrame(
+        np.array(
+            [
+                [1.0, 2.0],
+                [1.1, 2.1],
+                [0.9, 1.9],
+                [3.0, 4.0],
+                [3.1, 4.1],
+                [2.9, 3.9],
+            ]
+        ),
+        columns=["F1", "F2"],
+    )
+    labels = pd.Series(["A", "A", "A", "B", "B", "B"])
+
+    result = rf_mod.run_random_forest(df, labels, n_trees=10, cv_folds=3, top_n=2)
+
+    assert fit_calls == [2, 1]
+    assert score_calls == [(1, 1)]
+    assert predict_calls == [(1, 1)]
+    assert result.oob_accuracy == 0.91
+    assert result.cv_folds_used == 3

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -6,19 +6,11 @@ import pytest
 from core.input_resolver import resolve_primary_sheet_name_from_names
 from scripts.run_from_config import (
     _export_significant_features_excel,
-    _save_plotly_html,
     load_data,
     resolve_top_vip,
 )
 
 pytestmark = [pytest.mark.integration, pytest.mark.pr_smoke]
-
-try:
-    import plotly.graph_objects as go
-
-    HAS_PLOTLY = True
-except ImportError:
-    HAS_PLOTLY = False
 
 
 def _write_excel_with_sample_info(
@@ -389,20 +381,6 @@ def test_load_data_raises_when_sample_type_row_disagrees_with_sample_info(tmp_pa
                 },
             }
         )
-
-
-@pytest.mark.skipif(not HAS_PLOTLY, reason="plotly not installed")
-def test_save_plotly_html_writes_standalone_document(tmp_path: Path):
-    fig = go.Figure(data=go.Scatter(x=[1, 2], y=[3, 4]))
-    html_path = tmp_path / "interactive_plot.html"
-
-    saved = _save_plotly_html(fig, str(html_path))
-
-    assert saved is True
-    assert html_path.exists()
-    content = html_path.read_text(encoding="utf-8")
-    assert "<html" in content.lower()
-    assert "plotly" in content.lower()
 
 
 def test_resolve_primary_sheet_name_prefers_filename_hint_with_priority():

--- a/visualization/norm_preview.py
+++ b/visualization/norm_preview.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
+from matplotlib.patches import Patch
 from scipy.stats import gaussian_kde
 
 from visualization.theme import apply_publication_style, get_group_colors
@@ -41,30 +42,126 @@ def plot_norm_comparison(
     """
     apply_publication_style(theme)
     if fig is None:
-        fig = plt.figure(figsize=(12, 8))
+        fig = plt.figure(figsize=(13.5, 8.6))
     else:
         fig.clear()
 
-    labels_arr = labels.values if hasattr(labels, "values") else np.asarray(labels)
-    groups = sorted(set(labels_arr))
+    before_df = _coerce_frame(before_df, "before_df")
+    after_df = _coerce_frame(after_df, "after_df")
+    labels_arr = _coerce_labels(labels)
+    if len(labels_arr) != len(before_df) or len(labels_arr) != len(after_df):
+        raise ValueError("labels must align with both before_df and after_df rows.")
+
+    groups = _unique_preserve_order(labels_arr)
+    if not groups:
+        _draw_empty_norm_figure(fig, "Normalization Comparison", "No samples available.")
+        return fig
+
     palette = get_group_colors(theme, len(groups))
     color_map = dict(zip(groups, palette))
 
-    ax1 = fig.add_subplot(2, 2, 1)
-    _draw_group_box(ax1, before_df, labels_arr, groups, color_map, "Before Normalization")
+    before_min, before_max = _shared_value_limits(before_df, after_df)
+    density_x = np.linspace(before_min, before_max, 240)
 
-    ax2 = fig.add_subplot(2, 2, 2)
-    _draw_group_box(ax2, after_df, labels_arr, groups, color_map, "After Normalization")
+    gs = fig.add_gridspec(
+        2,
+        2,
+        height_ratios=(1.0, 1.05),
+        hspace=0.30,
+        wspace=0.18,
+    )
 
-    ax3 = fig.add_subplot(2, 2, 3)
-    _draw_density(ax3, before_df, labels_arr, groups, color_map, "Before Density")
+    ax1 = fig.add_subplot(gs[0, 0])
+    _draw_group_box(ax1, before_df, labels_arr, groups, color_map, "Before normalization")
+    ax1.set_title("Before normalization", fontsize=10.5, fontweight="bold", pad=8)
 
-    ax4 = fig.add_subplot(2, 2, 4)
-    _draw_density(ax4, after_df, labels_arr, groups, color_map, "After Density")
+    ax2 = fig.add_subplot(gs[0, 1])
+    _draw_group_box(ax2, after_df, labels_arr, groups, color_map, "After normalization")
+    ax2.set_title("After normalization", fontsize=10.5, fontweight="bold", pad=8)
 
-    fig.suptitle("Normalization Comparison", fontsize=13, fontweight="bold")
-    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    ax3 = fig.add_subplot(gs[1, 0])
+    _draw_density(ax3, before_df, labels_arr, groups, color_map, density_x, "Before density")
+    ax3.set_title("Before density", fontsize=10.5, fontweight="bold", pad=8)
+
+    ax4 = fig.add_subplot(gs[1, 1])
+    _draw_density(ax4, after_df, labels_arr, groups, color_map, density_x, "After density")
+    ax4.set_title("After density", fontsize=10.5, fontweight="bold", pad=8)
+
+    handles = [
+        Patch(facecolor=color_map[group], edgecolor=color_map[group], label=str(group), alpha=0.7)
+        for group in groups
+    ]
+    fig.suptitle("Normalization Comparison", fontsize=14, fontweight="bold", y=0.98)
+    fig.legend(
+        handles=handles,
+        loc="lower center",
+        bbox_to_anchor=(0.5, 0.02),
+        ncol=min(len(handles), 4),
+        frameon=False,
+        fontsize=8.5,
+    )
+    fig.text(
+        0.5,
+        0.06,
+        "Top row: grouped boxplots. Bottom row: density curves. Shared x-limits are used for direct before/after comparison.",
+        ha="center",
+        va="center",
+        fontsize=8,
+    )
+    fig.tight_layout(rect=[0.02, 0.10, 0.98, 0.95])
     return fig
+
+
+def _coerce_labels(labels) -> np.ndarray:
+    if hasattr(labels, "to_numpy"):
+        return np.asarray(labels.to_numpy())
+    if hasattr(labels, "values"):
+        return np.asarray(labels.values)
+    return np.asarray(labels)
+
+
+def _coerce_frame(df: pd.DataFrame, name: str) -> pd.DataFrame:
+    if not isinstance(df, pd.DataFrame):
+        df = pd.DataFrame(df)
+    if df.empty:
+        raise ValueError(f"{name} must not be empty.")
+    return df
+
+
+def _unique_preserve_order(values: np.ndarray) -> list:
+    seen = set()
+    ordered = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _shared_value_limits(*frames: pd.DataFrame) -> tuple[float, float]:
+    values = []
+    for df in frames:
+        arr = df.to_numpy(dtype=float).ravel()
+        arr = arr[np.isfinite(arr)]
+        if arr.size:
+            values.append(arr)
+    if not values:
+        return 0.0, 1.0
+
+    combined = np.concatenate(values)
+    if combined.size == 0:
+        return 0.0, 1.0
+
+    low, high = np.percentile(combined, [1, 99])
+    if not np.isfinite(low) or not np.isfinite(high):
+        low = float(np.nanmin(combined))
+        high = float(np.nanmax(combined))
+    if low == high:
+        pad = 1.0 if low == 0 else abs(low) * 0.1
+        low -= pad
+        high += pad
+    return float(low), float(high)
 
 
 def _draw_group_box(ax, df, labels_arr, groups, color_map, title: str) -> None:
@@ -80,28 +177,39 @@ def _draw_group_box(ax, df, labels_arr, groups, color_map, title: str) -> None:
 
     if not data_by_group:
         ax.set_title(title)
+        ax.set_axis_off()
         return
 
+    positions = np.arange(1, len(groups) + 1)
     boxplot = ax.boxplot(data_by_group, patch_artist=True, showfliers=False)
     for patch, color in zip(boxplot["boxes"], colors):
         patch.set_facecolor(color)
         patch.set_alpha(0.6)
 
-    ax.set_xticklabels([str(group)[:10] for group in groups], fontsize=8)
-    ax.set_title(title, fontsize=10)
-    ax.set_ylabel("Intensity")
+    for median in boxplot["medians"]:
+        median.set_color("#2F2F2F")
+        median.set_linewidth(1.0)
+
+    ax.set_xticks(positions)
+    ax.set_xticklabels([str(group)[:12] for group in groups], fontsize=8)
+    ax.set_ylabel("Intensity", fontsize=9.5)
+    ax.tick_params(axis="x", pad=2)
+    ax.grid(axis="y", alpha=0.12, linewidth=0.6)
+    ax.set_xlabel("Group", fontsize=9)
+    ax.set_xlim(0.5, len(groups) + 0.5)
 
 
-def _draw_density(ax, df, labels_arr, groups, color_map, title: str) -> None:
+def _draw_density(ax, df, labels_arr, groups, color_map, x_range, title: str) -> None:
     """Draw grouped density curves on an existing axes."""
     all_vals = df.to_numpy(dtype=float).ravel()
     all_vals = all_vals[np.isfinite(all_vals)]
     if len(all_vals) < 2:
         ax.set_title(title)
+        ax.set_axis_off()
         return
 
-    x_min, x_max = np.percentile(all_vals, [1, 99])
-    x_range = np.linspace(x_min, x_max, 200)
+    y_max = 0.0
+    density_cache = []
 
     for group in groups:
         mask = labels_arr == group
@@ -113,9 +221,31 @@ def _draw_density(ax, df, labels_arr, groups, color_map, title: str) -> None:
             kde = gaussian_kde(values)
         except Exception:
             continue
-        ax.plot(x_range, kde(x_range), color=color_map[group], alpha=0.7, label=str(group))
+        y_vals = kde(x_range)
+        density_cache.append((group, y_vals))
+        finite_y = y_vals[np.isfinite(y_vals)]
+        if finite_y.size:
+            y_max = max(y_max, float(np.nanmax(finite_y)))
+
+    if not density_cache:
+        ax.set_title(title)
+        ax.set_axis_off()
+        return
+
+    for group, y_vals in density_cache:
+        ax.plot(x_range, y_vals, color=color_map[group], alpha=0.85, linewidth=1.35)
 
     ax.set_xlabel("Intensity")
     ax.set_ylabel("Density")
-    ax.set_title(title, fontsize=10)
-    ax.legend(fontsize=7)
+    ax.grid(axis="y", alpha=0.12, linewidth=0.6)
+    ax.set_xlim(float(x_range[0]), float(x_range[-1]))
+    if y_max > 0:
+        ax.set_ylim(0, y_max * 1.08)
+
+
+def _draw_empty_norm_figure(fig: Figure, title: str, message: str) -> None:
+    fig.clf()
+    ax = fig.add_subplot(111)
+    ax.text(0.5, 0.5, message, ha="center", va="center", transform=ax.transAxes)
+    ax.set_axis_off()
+    fig.suptitle(title, fontsize=14, fontweight="bold", y=0.96)

--- a/visualization/oplsda_plot.py
+++ b/visualization/oplsda_plot.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
+from matplotlib.patches import Patch
 from matplotlib.lines import Line2D
 from matplotlib.patches import Ellipse
 from scipy.stats import chi2
@@ -249,37 +250,136 @@ def plot_oplsda_splot(
     apply_publication_style(theme)
 
     if fig is None:
-        fig = plt.figure(figsize=(8, 6))
+        fig = plt.figure(figsize=(8.8, 6.8))
     fig.clf()
     ax = fig.add_subplot(111)
 
     imp_df = oplsda_result.get_importance_df()
     if imp_df.empty:
-        ax.set_title("OPLS-DA S-Plot (no data)")
+        ax.text(
+            0.5,
+            0.5,
+            "OPLS-DA S-Plot\nNo importance data available.",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+            fontsize=11,
+        )
+        ax.set_axis_off()
+        fig.suptitle("OPLS-DA S-Plot", fontsize=13, fontweight="bold", y=0.97)
         fig.tight_layout()
         return fig
 
     loadings = imp_df["Loading"].to_numpy(dtype=float)
-    importance = imp_df["Importance"].to_numpy(dtype=float)
+    if "Importance" in imp_df.columns:
+        importance = imp_df["Importance"].to_numpy(dtype=float)
+    else:
+        importance = np.abs(loadings)
     features = imp_df["Feature"].astype(str).to_numpy()
-    palette = get_group_colors(theme, 2)
+    palette = get_group_colors(theme, 3)
+    positive_color = palette[0]
+    negative_color = palette[1]
+    neutral_color = palette[2] if len(palette) > 2 else palette[0]
 
-    ax.scatter(loadings, importance, c=palette[1], s=30, alpha=0.6, zorder=2)
+    pos_mask = loadings >= 0
+    neg_mask = ~pos_mask
+    ax.scatter(
+        loadings[neg_mask],
+        importance[neg_mask],
+        c=negative_color,
+        s=28,
+        alpha=0.55,
+        zorder=2,
+        label="Negative loading",
+    )
+    ax.scatter(
+        loadings[pos_mask],
+        importance[pos_mask],
+        c=positive_color,
+        s=28,
+        alpha=0.55,
+        zorder=2,
+        label="Positive loading",
+    )
 
-    top_idx = np.argsort(importance)[-top_n:]
-    for idx in top_idx:
+    top_idx = _select_balanced_annotation_indices(loadings, importance, top_n)
+    for rank, idx in enumerate(top_idx, start=1):
+        offset_x = 6 if loadings[idx] >= 0 else -6
+        align = "left" if offset_x > 0 else "right"
         ax.annotate(
-            features[idx][:20],
+            features[idx][:24],
             (loadings[idx], importance[idx]),
-            fontsize=7,
-            alpha=0.8,
-            xytext=(5, 5),
+            fontsize=7.2,
+            color=neutral_color,
+            alpha=0.95,
+            xytext=(offset_x, 5 if rank % 2 else -6),
             textcoords="offset points",
+            ha=align,
+            va="bottom" if rank % 2 else "top",
+            bbox={
+                "boxstyle": "round,pad=0.16",
+                "facecolor": "white",
+                "edgecolor": positive_color if loadings[idx] >= 0 else negative_color,
+                "linewidth": 0.6,
+                "alpha": 0.88,
+            },
         )
 
+    ax.axvline(0, color="grey", linewidth=0.8, linestyle="-", alpha=0.6)
+    ax.axhline(0, color="grey", linewidth=0.8, linestyle="-", alpha=0.35)
     ax.set_xlabel("Predictive Loading p[1]", fontsize=10)
-    ax.set_ylabel("|p[1]| (Importance)", fontsize=10)
-    ax.set_title("OPLS-DA S-Plot", fontsize=12, fontweight="bold")
-    ax.axvline(0, color="grey", linewidth=0.5, linestyle="-")
+    ax.set_ylabel("Absolute predictive loading |p[1]|", fontsize=10)
+    ax.set_title("OPLS-DA S-Plot", fontsize=13, fontweight="bold", pad=10)
+    ax.text(
+        0.01,
+        0.99,
+        f"Annotated top {len(top_idx)} features by |loading|",
+        transform=ax.transAxes,
+        ha="left",
+        va="top",
+        fontsize=8.5,
+        alpha=0.85,
+    )
+    ax.legend(
+        handles=[
+            Patch(facecolor=positive_color, edgecolor=positive_color, label="Positive loading", alpha=0.55),
+            Patch(facecolor=negative_color, edgecolor=negative_color, label="Negative loading", alpha=0.55),
+        ],
+        loc="upper right",
+        frameon=False,
+        fontsize=8.5,
+    )
+    ax.margins(x=0.08, y=0.12)
     fig.tight_layout()
     return fig
+
+
+def _select_balanced_annotation_indices(
+    loadings: np.ndarray,
+    importance: np.ndarray,
+    top_n: int,
+) -> list[int]:
+    """Pick a balanced set of positive/negative contributors for annotation."""
+    if top_n <= 0 or len(loadings) == 0:
+        return []
+
+    order = np.argsort(importance)[::-1]
+    positive = [int(idx) for idx in order if loadings[idx] >= 0]
+    negative = [int(idx) for idx in order if loadings[idx] < 0]
+
+    target_positive = int(np.ceil(top_n / 2))
+    target_negative = top_n - target_positive
+    selected = positive[:target_positive] + negative[:target_negative]
+
+    if len(selected) < top_n:
+        seen = set(selected)
+        for idx in order:
+            idx = int(idx)
+            if idx in seen:
+                continue
+            selected.append(idx)
+            seen.add(idx)
+            if len(selected) >= top_n:
+                break
+
+    return selected[:top_n]


### PR DESCRIPTION
## Summary
- codify the repo-local `run.cmd` workflow guidance so natural-language requests map cleanly onto the supported PowerShell / `run.cmd "<input.xlsx>" "<config.yaml>"` contract
- refactor batch report export in `scripts/run_from_config.py` into a publication-oriented layout with `01_QC_and_Preprocessing` through `05_Supplementary`
- add higher-value batch figures for the publication path, including normalization comparison, heatmap, OPLS-DA S-plot, ROC/AUC, and supplementary Random Forest outputs
- improve the normalization comparison and OPLS-DA S-plot visuals for static batch export readability
- add smoke coverage for the new report contract and harden Random Forest execution with a Windows permission-error fallback to single-process mode

## Why
The previous batch output mixed high-value report figures with low-value or redundant artifacts in a flat folder, which made the CLI report noisy and harder to use as a publication-oriented deliverable. At the same time, the repo-local run contract and agent guidance had drifted away from the actual workflow, making it too easy for future sessions to rediscover the wrong entry point.

This PR tightens both surfaces:
- the operator contract is clearer and easier to trigger reliably
- the batch output is grouped by analysis narrative instead of dumping every artifact into one directory
- the real preset path now completes end-to-end, including Random Forest supplementary outputs on Windows

## What Changed
### Workflow / docs
- clean up stale repo-local `AGENT.md` guidance
- add the repo-local `run-cmd-contract` skill and hook companion files
- add a publication-batch implementation guide at `docs/plans/2026-04-11-publication-batch-report-v1.md`

### Batch report exports
- remove low-value default exports such as PCA scree/loading and standalone sample distribution figures from the batch default path
- add report subfolders:
  - `01_QC_and_Preprocessing`
  - `02_Global_Profiling`
  - `03_Feature_Selection`
  - `04_Biomarker_Validation`
  - `05_Supplementary`
- add batch exports for:
  - normalization comparison
  - PCA score plot
  - heatmap top-50
  - OPLS-DA score + S-plot
  - volcano plots
  - PLS-DA VIP plots
  - ROC curves + AUC ranking
  - supplementary outlier plots
  - supplementary Random Forest importance + confusion matrix
  - supplementary top-N ANOVA boxplots
- keep root-level tabular outputs such as processed matrices, labels, config copy, CSV summaries, and significant-features workbook

### Reliability
- support both legacy `log2_fc_thresh` and explicit `fc_thresh` volcano config styles
- add Random Forest fallback behavior when Windows parallel backends raise `PermissionError: [WinError 5]`

## Validation
### Targeted checks
- `python -m py_compile analysis\random_forest.py scripts\run_from_config.py visualization\norm_preview.py visualization\oplsda_plot.py tests\test_random_forest_njobs.py tests\test_publication_batch_report_smoke.py`
- `uv run pytest tests\test_publication_batch_report_smoke.py -q`
- `uv run pytest tests\test_random_forest_njobs.py tests\test_analysis_edgecases.py -q`

### Real preset run
- `cmd /c run.cmd "C:\Users\user\Desktop\NTU cancer\Processed Data\DNA\Mzmine\new_test\run_20260406_025159\Step4_Normalized_PQN.xlsx" "configs\Tissue_knn_rsd050_marker_verify.yaml" -Suffix "_rf_fix_check"`
- verified the publication-oriented folder structure and confirmed Random Forest supplementary outputs are now emitted successfully
