### PR TITLE
feat: publication report v2 — figure quality & table organization

### DIFF
--- a/docs/superpowers/plans/2026-04-12-publication-report-v2.md
+++ b/docs/superpowers/plans/2026-04-12-publication-report-v2.md
@@ -1,0 +1,897 @@
+# Publication Report V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade batch report exports to publication-grade quality — reorganize tables into report directories, improve all figure rendering to meet scientific journal standards.
+
+**Architecture:** Add a `apply_publication_export_style()` function to `theme.py` that batch export calls at startup. Upgrade `_save_figure` in `run_from_config.py` to dual-output PNG+PDF with `draft_mode` opt-out. Move all CSV/Excel outputs into the existing `REPORT_SUBDIRS` structure. Fix per-plot issues (ellipse fill, jitter, legend, alignment) in individual visualization modules.
+
+**Tech Stack:** matplotlib, seaborn, numpy, adjustText, openpyxl
+
+**Spec:** `docs/superpowers/specs/2026-04-12-publication-report-v2-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `visualization/theme.py` | Modify | Add `apply_publication_export_style()` |
+| `scripts/run_from_config.py` | Modify | `_save_figure` upgrade, table path reorganization, `draft_mode`, pipeline log export, confusion matrix vmax coordination |
+| `visualization/oplsda_plot.py` | Modify | Ellipse fill removal, adjustText on S-plot |
+| `visualization/anova_plot.py` | Modify | Jitter overlay on boxplot |
+| `visualization/outlier_plot.py` | Modify | 2:1 figsize, GridSpec alignment, adjustText |
+| `visualization/heatmap.py` | Modify | Already handles >50 features — verify only |
+| `visualization/volcano_plot.py` | Modify | Legend position fix |
+| `visualization/density_plot.py` | Modify | Legend position fix |
+| `visualization/rf_plot.py` | Modify | Confusion matrix `vmin`/`vmax` parameter |
+| `tests/test_publication_export_v2.py` | Create | Smoke tests for all changes |
+
+---
+
+### Task 1: Publication Export Style + `_save_figure` Upgrade
+
+**Files:**
+- Modify: `visualization/theme.py:73-127`
+- Modify: `scripts/run_from_config.py:92-96`
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write failing tests for publication export style and dual-output save**
+
+```python
+# tests/test_publication_export_v2.py
+"""Smoke tests for publication report v2 improvements."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+
+class TestPublicationExportStyle:
+    """Tests for apply_publication_export_style."""
+
+    def test_sets_arial_font(self):
+        from visualization.theme import apply_publication_export_style
+        apply_publication_export_style("light")
+        assert plt.rcParams["font.family"] == "Arial"
+
+    def test_sets_300_dpi(self):
+        from visualization.theme import apply_publication_export_style
+        apply_publication_export_style("light")
+        assert plt.rcParams["savefig.dpi"] == 300
+        assert plt.rcParams["figure.dpi"] == 300
+
+    def test_inherits_base_style(self):
+        from visualization.theme import apply_publication_export_style
+        apply_publication_export_style("light")
+        # Base style properties should still be set
+        assert plt.rcParams["axes.spines.top"] is False
+        assert plt.rcParams["axes.spines.right"] is False
+        assert plt.rcParams["legend.frameon"] is False
+
+
+class TestSaveFigureDualOutput:
+    """Tests for _save_figure dual PNG+PDF output."""
+
+    def test_publication_mode_creates_png_and_pdf(self, tmp_path):
+        from scripts.run_from_config import _save_figure
+        fig = plt.figure()
+        fig.add_subplot(111).plot([1, 2], [3, 4])
+        out = tmp_path / "test.png"
+        _save_figure(fig, out, draft_mode=False)
+        assert out.exists()
+        assert out.with_suffix(".pdf").exists()
+
+    def test_draft_mode_creates_png_only(self, tmp_path):
+        from scripts.run_from_config import _save_figure
+        fig = plt.figure()
+        fig.add_subplot(111).plot([1, 2], [3, 4])
+        out = tmp_path / "test.png"
+        _save_figure(fig, out, draft_mode=True)
+        assert out.exists()
+        assert not out.with_suffix(".pdf").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_publication_export_v2.py -v`
+Expected: FAIL — `apply_publication_export_style` does not exist, `_save_figure` does not accept `draft_mode`.
+
+- [ ] **Step 3: Implement `apply_publication_export_style` in theme.py**
+
+Add after `apply_publication_style` (after line 127):
+
+```python
+def apply_publication_export_style(theme: str = "light") -> None:
+    """
+    Apply publication-grade export rcParams for batch report generation.
+
+    Builds on ``apply_publication_style`` then overrides with journal-grade
+    settings: Arial font, 300 DPI, and tighter typographic sizes.
+
+    Intended for ``run_from_config.py`` batch exports — GUI preview should
+    continue using ``apply_publication_style`` for speed.
+
+    Corresponds to R function: N/A (MetaboAnalyst uses fixed R device settings).
+    """
+    apply_publication_style(theme)
+    plt.rcParams.update(
+        {
+            "font.family": "Arial",
+            "savefig.dpi": 300,
+            "figure.dpi": 300,
+        }
+    )
+```
+
+- [ ] **Step 4: Upgrade `_save_figure` in run_from_config.py**
+
+Replace lines 92–95:
+
+```python
+def _save_figure(fig: Any, path: Path, *, draft_mode: bool = False) -> None:
+    """Save a matplotlib figure as PNG (and PDF in publication mode), then close."""
+    if draft_mode:
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+    else:
+        fig.savefig(path, dpi=300, bbox_inches="tight")
+        fig.savefig(path.with_suffix(".pdf"), bbox_inches="tight")
+    plt.close(fig)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestPublicationExportStyle -v && uv run pytest tests/test_publication_export_v2.py::TestSaveFigureDualOutput -v`
+Expected: All PASS.
+
+- [ ] **Step 6: Wire `draft_mode` and publication style into `run_analysis`**
+
+In `run_from_config.py`, at the top of `run_analysis()` (after line 558 `os.makedirs`), add:
+
+```python
+    draft_mode = bool(cfg.get("output", {}).get("draft_mode", False))
+    if not draft_mode:
+        from visualization.theme import apply_publication_export_style
+        apply_publication_export_style()
+```
+
+Then find-and-replace every `_save_figure(fig, ...)` call in the file to add `draft_mode=draft_mode`. There are approximately 15 calls — each one gets the kwarg appended:
+
+```python
+    _save_figure(fig, report_dirs["qc"] / "normalization_comparison.png", draft_mode=draft_mode)
+    # ... same pattern for all other _save_figure calls
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add visualization/theme.py scripts/run_from_config.py tests/test_publication_export_v2.py
+git commit -m "feat: add publication export style and dual PNG+PDF output"
+```
+
+---
+
+### Task 2: Table Reorganization into Report Directories
+
+**Files:**
+- Modify: `scripts/run_from_config.py:660-680` (QC tables), `720-722` (ANOVA CSV), `965-968` (volcano CSV), `1008-1010` (ROC CSV), `1036-1039` (outlier CSV), `1077-1080` (RF CSV), `1095-1098` (paired audit)
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write failing test for table placement**
+
+Append to `tests/test_publication_export_v2.py`:
+
+```python
+class TestTableReorganization:
+    """Verify CSV/YAML files land in correct report subdirectories."""
+
+    def test_qc_tables_in_01_dir(self):
+        """QC-related files should be in 01_QC_and_Preprocessing."""
+        from scripts.run_from_config import REPORT_SUBDIRS
+        qc_files = [
+            "processed_data.csv",
+            "sample_labels.csv",
+            "feature_metadata.csv",
+            "config_used.yaml",
+            "pipeline_log.txt",
+        ]
+        # Verify the mapping constant exists
+        assert "qc" in REPORT_SUBDIRS
+        assert REPORT_SUBDIRS["qc"] == "01_QC_and_Preprocessing"
+        # Files should be expected in that subdir (integration test verifies actual placement)
+        for f in qc_files:
+            assert f  # placeholder — real placement tested in integration
+
+    def test_feature_tables_in_03_dir(self):
+        from scripts.run_from_config import REPORT_SUBDIRS
+        assert "feature" in REPORT_SUBDIRS
+        assert REPORT_SUBDIRS["feature"] == "03_Feature_Selection"
+
+    def test_validation_tables_in_04_dir(self):
+        from scripts.run_from_config import REPORT_SUBDIRS
+        assert "validation" in REPORT_SUBDIRS
+        assert REPORT_SUBDIRS["validation"] == "04_Biomarker_Validation"
+
+    def test_supplementary_tables_in_05_dir(self):
+        from scripts.run_from_config import REPORT_SUBDIRS
+        assert "supplementary" in REPORT_SUBDIRS
+        assert REPORT_SUBDIRS["supplementary"] == "05_Supplementary"
+```
+
+- [ ] **Step 2: Run test to verify it passes (constants already exist)**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestTableReorganization -v`
+Expected: PASS (REPORT_SUBDIRS already defined).
+
+- [ ] **Step 3: Move QC table outputs to `01_QC_and_Preprocessing/`**
+
+In `run_from_config.py`, replace lines 664–681 (the block that saves processed_data.csv through config_used.yaml):
+
+```python
+    # Save processed data — QC directory
+    processed.to_csv(os.path.join(report_dirs["qc"], "processed_data.csv"))
+    final_labels.to_csv(os.path.join(report_dirs["qc"], "sample_labels.csv"))
+    final_feature_metadata.to_csv(
+        os.path.join(report_dirs["qc"], "feature_metadata.csv"),
+        index_label="Feature",
+    )
+    qc_rsd_audit = pipeline.step_feature_metadata.get("qc_rsd")
+    if qc_rsd_audit is not None and not qc_rsd_audit.empty:
+        qc_rsd_audit.to_csv(
+            os.path.join(report_dirs["qc"], "qc_rsd_audit.csv"),
+            index_label="Feature",
+        )
+
+    # Save config used
+    config_copy_path = os.path.join(report_dirs["qc"], "config_used.yaml")
+    with open(config_copy_path, "w", encoding="utf-8") as f:
+        f.write(dump_yaml(cfg, include_runtime=False))
+
+    # Save pipeline log
+    log_path = os.path.join(report_dirs["qc"], "pipeline_log.txt")
+    with open(log_path, "w", encoding="utf-8") as f:
+        for line in pipeline.log:
+            f.write(line + "\n")
+    print(f"  Saved to {output_dir}")
+```
+
+- [ ] **Step 4: Move ANOVA CSV to `03_Feature_Selection/`**
+
+Replace line 722:
+```python
+    anova_result.result_df.to_csv(os.path.join(report_dirs["feature"], "anova_results.csv"), index=False)
+```
+
+- [ ] **Step 5: Move Volcano CSV to `03_Feature_Selection/`**
+
+Replace lines 965–968:
+```python
+            vresult.result_df.to_csv(
+                os.path.join(report_dirs["feature"], f"volcano_{g1}_vs_{g2}.csv"),
+                index=False,
+            )
+```
+
+- [ ] **Step 6: Move ROC CSV to `04_Biomarker_Validation/`**
+
+Replace lines 1008–1010:
+```python
+            roc_result.summary_df.to_csv(
+                os.path.join(report_dirs["validation"], f"roc_{g1}_vs_{g2}.csv"),
+                index=False,
+            )
+```
+
+- [ ] **Step 7: Move RF CSV to `05_Supplementary/`**
+
+Replace lines 1077–1080:
+```python
+            rf_result.feature_importance.to_csv(
+                os.path.join(report_dirs["supplementary"], f"rf_importance_{g1}_vs_{g2}.csv"),
+                index=False,
+            )
+```
+
+- [ ] **Step 8: Move Outlier CSV to `05_Supplementary/`**
+
+Replace lines 1036–1039:
+```python
+        outlier_result.get_outlier_df().to_csv(
+            os.path.join(report_dirs["supplementary"], "outlier_results.csv"),
+            index=False,
+        )
+```
+
+- [ ] **Step 9: Move Paired Audit CSV to `05_Supplementary/`**
+
+Replace lines 1096–1097:
+```python
+        audit_path = os.path.join(report_dirs["supplementary"], "paired_resolution_audit.csv")
+```
+
+- [ ] **Step 10: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: All pass — no existing tests depend on exact output paths.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add scripts/run_from_config.py tests/test_publication_export_v2.py
+git commit -m "refactor: organize table exports into report subdirectories"
+```
+
+---
+
+### Task 3: OPLS-DA Ellipse Fill Removal + S-Plot adjustText
+
+**Files:**
+- Modify: `visualization/oplsda_plot.py:41-53` (ellipse), `305-326` (S-plot annotations)
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_publication_export_v2.py`:
+
+```python
+class TestOplsdaEllipseNoFill:
+    """OPLS-DA confidence ellipses should have no fill."""
+
+    def test_ellipse_has_no_facecolor(self):
+        from visualization.oplsda_plot import _confidence_ellipse
+        fig, ax = plt.subplots()
+        x = np.random.randn(20)
+        y = np.random.randn(20)
+        _confidence_ellipse(ax, x, y, color="#E64B35", fill_color="#E64B35")
+        patches = [p for p in ax.patches if hasattr(p, "get_facecolor")]
+        assert len(patches) == 1
+        fc = patches[0].get_facecolor()
+        # facecolor alpha should be 0 (transparent) — "none" fill
+        assert fc[3] == 0.0 or patches[0].get_fill() is False
+        plt.close(fig)
+
+    def test_ellipse_has_dashed_linestyle(self):
+        from visualization.oplsda_plot import _confidence_ellipse
+        fig, ax = plt.subplots()
+        x = np.random.randn(20)
+        y = np.random.randn(20)
+        _confidence_ellipse(ax, x, y, color="#E64B35", fill_color="#E64B35")
+        patches = [p for p in ax.patches if hasattr(p, "get_linestyle")]
+        assert len(patches) == 1
+        ls = patches[0].get_linestyle()
+        # Dashed line produces a tuple sequence, not solid (0, None)
+        assert ls != (0, None)  # not solid
+        plt.close(fig)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestOplsdaEllipseNoFill -v`
+Expected: FAIL — ellipse currently has `facecolor=fill_color, alpha=0.25`.
+
+- [ ] **Step 3: Modify `_confidence_ellipse` in oplsda_plot.py**
+
+Replace lines 41–53 (the `ax.add_patch(Ellipse(...))` block):
+
+```python
+    ax.add_patch(
+        Ellipse(
+            xy=(np.mean(x), np.mean(y)),
+            width=width,
+            height=height,
+            angle=angle,
+            facecolor="none",
+            edgecolor=color,
+            linestyle="--",
+            linewidth=1.2,
+            zorder=1,
+        )
+    )
+```
+
+- [ ] **Step 4: Add adjustText to S-plot annotations**
+
+At the top of `oplsda_plot.py`, add import (near other imports):
+
+```python
+try:
+    from adjustText import adjust_text
+    _HAS_ADJUSTTEXT = True
+except ImportError:
+    _HAS_ADJUSTTEXT = False
+```
+
+Replace lines 305–326 (the annotation loop in `plot_oplsda_splot`) with:
+
+```python
+    top_idx = _select_balanced_annotation_indices(loadings, importance, top_n)
+    texts = []
+    for rank, idx in enumerate(top_idx, start=1):
+        txt = ax.text(
+            loadings[idx],
+            importance[idx],
+            features[idx][:24],
+            fontsize=7.2,
+            color=neutral_color,
+            alpha=0.95,
+            ha="left" if loadings[idx] >= 0 else "right",
+            va="bottom" if rank % 2 else "top",
+            bbox={
+                "boxstyle": "round,pad=0.16",
+                "facecolor": "white",
+                "edgecolor": positive_color if loadings[idx] >= 0 else negative_color,
+                "linewidth": 0.6,
+                "alpha": 0.88,
+            },
+        )
+        texts.append(txt)
+
+    if texts and _HAS_ADJUSTTEXT:
+        adjust_text(
+            texts,
+            ax=ax,
+            arrowprops=dict(arrowstyle="-", color=neutral_color, lw=0.5),
+        )
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestOplsdaEllipseNoFill -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add visualization/oplsda_plot.py tests/test_publication_export_v2.py
+git commit -m "fix: remove OPLS-DA ellipse fill and add adjustText to S-plot"
+```
+
+---
+
+### Task 4: ANOVA Boxplot Jitter
+
+**Files:**
+- Modify: `visualization/anova_plot.py:128-163`
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_publication_export_v2.py`:
+
+```python
+class TestAnovaBoxplotJitter:
+    """ANOVA boxplot should overlay jittered data points."""
+
+    def test_scatter_points_present(self):
+        from visualization.anova_plot import _draw_r_style_boxplot
+        from visualization.theme import COLORS
+
+        fig, ax = plt.subplots()
+        config = COLORS["light"]
+        data = [np.array([1.0, 2.0, 3.0, 4.0, 5.0]), np.array([2.0, 3.0, 4.0, 5.0, 6.0])]
+        _draw_r_style_boxplot(ax, data, ["A", "B"], ["#E64B35", "#4DBBD5"], config)
+
+        # PathCollection = scatter plot points
+        scatter_collections = [
+            c for c in ax.collections
+            if type(c).__name__ == "PathCollection"
+        ]
+        assert len(scatter_collections) >= 2, "Expected jittered scatter overlays for each group"
+        plt.close(fig)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestAnovaBoxplotJitter -v`
+Expected: FAIL — no scatter overlays currently.
+
+- [ ] **Step 3: Add jitter overlay to `_draw_r_style_boxplot`**
+
+In `visualization/anova_plot.py`, add the jitter scatter inside the loop (after the `ax.plot(... marker="D" ...)` block at line 163, before the loop ends):
+
+```python
+        # Overlay jittered raw data points
+        jitter = np.random.default_rng(42).uniform(-0.15, 0.15, size=len(clean))
+        ax.scatter(
+            positions[idx] + jitter,
+            clean,
+            c=color,
+            s=18,
+            alpha=0.5,
+            edgecolors="white",
+            linewidths=0.3,
+            zorder=3,
+        )
+```
+
+This adds after the mean diamond (zorder=4) but above the box (zorder=2 default). The fixed seed `rng(42)` ensures reproducibility.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestAnovaBoxplotJitter -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add visualization/anova_plot.py tests/test_publication_export_v2.py
+git commit -m "feat: add jittered data points to ANOVA boxplot"
+```
+
+---
+
+### Task 5: Outlier Plot 2:1 Aspect Ratio + Alignment + adjustText
+
+**Files:**
+- Modify: `visualization/outlier_plot.py:44-45` (figsize), `69` (subplot), `137-144` (annotations), `221` (DModX figsize), `250-258` (DModX annotations)
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_publication_export_v2.py`:
+
+```python
+class TestOutlierPlotLayout:
+    """Outlier side-by-side should use 2:1 aspect ratio."""
+
+    def test_outlier_score_figsize_2_to_1(self):
+        from analysis.outlier import OutlierResult
+        from visualization.outlier_plot import plot_outlier_score
+
+        # Minimal mock result
+        n = 10
+        result = OutlierResult(
+            scores=np.random.randn(n, 2),
+            t2_values=np.random.rand(n) * 10,
+            t2_threshold=6.0,
+            outlier_mask_t2=np.array([False] * 9 + [True]),
+            dmodx=np.random.rand(n),
+            dmodx_threshold=2.0,
+            outlier_mask_dmodx=np.array([False] * 9 + [True]),
+            explained_variance=np.array([0.4, 0.3]),
+            sample_names=[f"S{i}" for i in range(n)],
+        )
+        fig = plot_outlier_score(result)
+        w, h = fig.get_size_inches()
+        ratio = w / h
+        assert 2.0 <= ratio <= 2.5, f"Expected ~2:1 ratio, got {ratio:.2f}"
+        plt.close(fig)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestOutlierPlotLayout -v`
+Expected: FAIL — current figsize is `(10, 5)` = 2:1 but let's verify.
+
+- [ ] **Step 3: Update outlier_plot.py figsize and alignment**
+
+In `visualization/outlier_plot.py`:
+
+Change line 45 from `figsize=(10, 5)` to:
+```python
+        fig = plt.figure(figsize=(16, 7))
+```
+
+Replace `fig.add_subplot(121)` (line 69) and `fig.add_subplot(122)` (line 173) with GridSpec for strict alignment. At line 69, replace:
+
+```python
+    gs = fig.add_gridspec(1, 2, wspace=0.3)
+    ax1 = fig.add_subplot(gs[0, 0])
+```
+
+And at line 173 (the second subplot), replace `ax2 = fig.add_subplot(122)` with:
+```python
+    ax2 = fig.add_subplot(gs[0, 1])
+```
+
+At the end of the function (before `return fig`), add:
+```python
+    fig.align_ylabels([ax1, ax2])
+```
+
+- [ ] **Step 4: Add adjustText to outlier annotations**
+
+Add import at top of `outlier_plot.py`:
+
+```python
+try:
+    from adjustText import adjust_text
+    _HAS_ADJUSTTEXT = True
+except ImportError:
+    _HAS_ADJUSTTEXT = False
+```
+
+Replace outlier annotation loop (lines 137–144) with:
+
+```python
+    outlier_texts = []
+    for idx in np.where(outlier_mask)[0]:
+        txt = ax1.text(
+            x[idx], y[idx], str(sample_names[idx]),
+            fontsize=7, color=config["text"], alpha=0.9,
+        )
+        outlier_texts.append(txt)
+    if outlier_texts and _HAS_ADJUSTTEXT:
+        adjust_text(outlier_texts, ax=ax1,
+                    arrowprops=dict(arrowstyle="-", color=config["text"], lw=0.5))
+```
+
+Apply same pattern to DModX annotations (lines 250–258).
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestOutlierPlotLayout -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add visualization/outlier_plot.py tests/test_publication_export_v2.py
+git commit -m "fix: outlier plot 2:1 aspect ratio with GridSpec alignment and adjustText"
+```
+
+---
+
+### Task 6: Legend Position Fixes (Volcano, Density, Boxplot)
+
+**Files:**
+- Modify: `visualization/volcano_plot.py:107`
+- Modify: `visualization/density_plot.py:83`
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_publication_export_v2.py`:
+
+```python
+class TestLegendPositions:
+    """Verify loc='best' is never used in publication plots."""
+
+    def test_volcano_legend_not_best(self):
+        import visualization.volcano_plot as vp
+        source = open(vp.__file__).read()
+        assert 'loc="best"' not in source, "volcano_plot still uses loc='best'"
+
+    def test_density_legend_not_best(self):
+        import visualization.density_plot as dp
+        source = open(dp.__file__).read()
+        assert 'loc="best"' not in source, "density_plot still uses loc='best'"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestLegendPositions -v`
+Expected: FAIL — both files use `loc="best"`.
+
+- [ ] **Step 3: Fix volcano legend**
+
+In `visualization/volcano_plot.py`, change line 107:
+
+```python
+    ax.legend(loc="upper right", fontsize=8)
+```
+
+- [ ] **Step 4: Fix density legend**
+
+In `visualization/density_plot.py`, change line 83:
+
+```python
+    ax.legend(loc="upper right", fontsize=9)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestLegendPositions -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add visualization/volcano_plot.py visualization/density_plot.py tests/test_publication_export_v2.py
+git commit -m "fix: replace loc='best' legends with fixed positions"
+```
+
+---
+
+### Task 7: Confusion Matrix Unified Color Scale
+
+**Files:**
+- Modify: `visualization/rf_plot.py:83-129`
+- Modify: `scripts/run_from_config.py:1060-1093`
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_publication_export_v2.py`:
+
+```python
+class TestConfusionMatrixVmax:
+    """Confusion matrix should accept vmax for cross-pair consistency."""
+
+    def test_accepts_vmax_parameter(self):
+        import inspect
+        from visualization.rf_plot import plot_confusion_matrix
+        sig = inspect.signature(plot_confusion_matrix)
+        assert "vmax" in sig.parameters, "plot_confusion_matrix should accept vmax parameter"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestConfusionMatrixVmax -v`
+Expected: FAIL — no `vmax` parameter currently.
+
+- [ ] **Step 3: Add `vmax` parameter to `plot_confusion_matrix`**
+
+In `visualization/rf_plot.py`, modify the function signature and heatmap call:
+
+```python
+def plot_confusion_matrix(
+    rf_result,
+    theme: str = "light",
+    fig: Figure | None = None,
+    vmax: int | None = None,
+) -> Figure:
+    apply_publication_style(theme)
+    if fig is None:
+        fig = plt.figure(figsize=(6, 5))
+    fig.clf()
+    ax = fig.add_subplot(111)
+
+    cm = rf_result.confusion_mat
+    class_names = rf_result.class_names
+    cmap = sns.light_palette(get_group_colors(theme, 1)[0], as_cmap=True)
+
+    heatmap_kwargs: dict = dict(
+        annot=True,
+        fmt="d",
+        cmap=cmap,
+        xticklabels=class_names,
+        yticklabels=class_names,
+        ax=ax,
+        linewidths=0.5,
+        vmin=0,
+    )
+    if vmax is not None:
+        heatmap_kwargs["vmax"] = vmax
+
+    sns.heatmap(cm, **heatmap_kwargs)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("True")
+    ax.set_title(f"Confusion Matrix (CV)\nAccuracy {rf_result.cv_accuracy:.1%}")
+    fig.tight_layout()
+    return fig
+```
+
+- [ ] **Step 4: Coordinate vmax across pairs in run_from_config.py**
+
+In `scripts/run_from_config.py`, restructure the RF section (lines 1060–1093) to two passes:
+
+```python
+    # ── Supplementary: random forest ─────────────────────
+    print("\n" + "=" * 60)
+    print("Generating supplementary Random Forest plots...")
+    rf_cfg = analysis_cfg.get("random_forest", {})
+    rf_trees = int(rf_cfg.get("n_trees", 500))
+    rf_cv_folds = int(rf_cfg.get("cv_folds", 5))
+    rf_top_n = int(rf_cfg.get("top_n", 25))
+
+    # Pass 1: collect RF results and find global vmax for confusion matrices
+    rf_results: list[tuple[str, str, Any]] = []
+    global_cm_vmax = 0
+    for g1, g2 in report_pairs:
+        print(f"  RF {g1} vs {g2}...")
+        try:
+            pair_mask = final_labels.isin([g1, g2])
+            pair_data = processed.loc[pair_mask]
+            pair_labels = final_labels.loc[pair_mask]
+            if pair_data.empty or pair_labels.nunique() < 2:
+                print("    Skipped (not enough pairwise samples)")
+                continue
+
+            rf_result = run_random_forest(
+                pair_data, pair_labels,
+                n_trees=rf_trees, cv_folds=rf_cv_folds, top_n=rf_top_n,
+            )
+            rf_results.append((g1, g2, rf_result))
+            global_cm_vmax = max(global_cm_vmax, int(rf_result.confusion_mat.max()))
+        except Exception as e:
+            print(f"    Error: {e}")
+
+    # Pass 2: render figures with unified color scale
+    for g1, g2, rf_result in rf_results:
+        rf_result.feature_importance.to_csv(
+            os.path.join(report_dirs["supplementary"], f"rf_importance_{g1}_vs_{g2}.csv"),
+            index=False,
+        )
+
+        fig = plt.figure(figsize=(8, 6))
+        plot_rf_importance(rf_result, top_n=rf_top_n, fig=fig)
+        _save_figure(fig, report_dirs["supplementary"] / f"rf_importance_{g1}_vs_{g2}.png",
+                     draft_mode=draft_mode)
+
+        fig = plt.figure(figsize=(6, 5))
+        plot_confusion_matrix(rf_result, fig=fig, vmax=global_cm_vmax if len(rf_results) > 1 else None)
+        _save_figure(fig, report_dirs["supplementary"] / f"rf_confusion_matrix_{g1}_vs_{g2}.png",
+                     draft_mode=draft_mode)
+
+        print(f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_importance_{g1}_vs_{g2}.png")
+        print(f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_confusion_matrix_{g1}_vs_{g2}.png")
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestConfusionMatrixVmax -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add visualization/rf_plot.py scripts/run_from_config.py tests/test_publication_export_v2.py
+git commit -m "feat: unified confusion matrix color scale across comparison pairs"
+```
+
+---
+
+### Task 8: Heatmap Verification + Final Test Suite
+
+**Files:**
+- Verify: `visualization/heatmap.py:85-87`
+- Test: `tests/test_publication_export_v2.py`
+
+- [ ] **Step 1: Write verification test**
+
+Append to `tests/test_publication_export_v2.py`:
+
+```python
+class TestHeatmapLabelThreshold:
+    """Heatmap should hide x-labels when features > 50."""
+
+    def test_xticklabels_hidden_when_many_features(self):
+        import visualization.heatmap as hm
+        source = open(hm.__file__).read()
+        # Verify the conditional xticklabels logic exists
+        assert "xticklabels=False" in source
+        assert "50" in source
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `uv run pytest tests/test_publication_export_v2.py::TestHeatmapLabelThreshold -v`
+Expected: PASS — heatmap.py already has this logic at lines 85–86.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: All pass.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add tests/test_publication_export_v2.py
+git commit -m "test: add publication report v2 smoke test suite"
+```
+
+---
+
+## Task Dependency Order
+
+```
+Task 1 (theme + _save_figure)
+  └→ Task 2 (table reorganization) — uses draft_mode from Task 1
+  └→ Task 3 (OPLS-DA ellipse + S-plot)
+  └→ Task 4 (ANOVA jitter)
+  └→ Task 5 (Outlier layout)
+  └→ Task 6 (Legend fixes)
+  └→ Task 7 (Confusion matrix) — depends on Task 2 for report_dirs paths
+  └→ Task 8 (Heatmap verify + final tests)
+```
+
+Tasks 3–6 are independent and can run in parallel after Task 1.
+Task 7 depends on Task 1 + Task 2.
+Task 8 runs last as the integration gate.

--- a/docs/superpowers/specs/2026-04-12-publication-report-v2-design.md
+++ b/docs/superpowers/specs/2026-04-12-publication-report-v2-design.md
@@ -1,0 +1,197 @@
+# Publication Report V2 — Figure Quality & Table Organization
+
+**Date:** 2026-04-12
+**Status:** Approved
+**Scope:** `run_from_config.py` batch export pipeline + visualization modules
+
+---
+
+## Problem Statement
+
+PR #8 introduced publication batch report exports but only addressed figures partially.
+Remaining issues:
+
+1. **Tables** — CSV/Excel files are scattered in the output root instead of organized into
+   the report directory structure (`01_QC/`, `02_Global/`, etc.)
+2. **Figures** — Legend occlusion, inconsistent proportions, print-unfriendly confidence
+   ellipses, missing jitter on boxplots, and other quality gaps identified via expert review.
+
+---
+
+## Design Decisions
+
+### D1: Publication Export Profile — Default On, Opt-Out via Config
+
+Batch export (`run_from_config.py`) defaults to publication-grade settings.
+A `draft_mode: true` config option downgrades to fast preview.
+
+```yaml
+output:
+  # draft_mode: true   # Uncomment for 150 dpi, PNG-only quick preview
+```
+
+### D2: Dual Output Format
+
+Non-draft mode produces **PNG (300 DPI) + PDF (vector)** for every figure.
+Draft mode produces PNG (150 DPI) only.
+
+### D3: Table Organization Follows Figure Directories
+
+Tables land in the same report subdirectory as their companion figures.
+`significant_features_summary.xlsx` and `Summary.csv` stay at root (cross-analysis).
+
+### D4: ms-core Boxplot Jitter
+
+Jitter is a universal boxplot best practice — fix at source in ms-core submodule,
+not via a local wrapper.
+
+---
+
+## Section 1: Publication Export Profile
+
+### New function in `visualization/theme.py`
+
+```python
+def apply_publication_export_style(theme: str = "light") -> None:
+    apply_publication_style(theme)
+    plt.rcParams.update({
+        "font.family": "Arial",
+        "savefig.dpi": 300,
+        "figure.dpi": 300,
+        "axes.titlesize": 14,
+        "axes.labelsize": 12,
+        "xtick.labelsize": 10,
+        "ytick.labelsize": 10,
+        "legend.fontsize": 10,
+    })
+```
+
+### Upgraded `_save_figure` in `run_from_config.py`
+
+```python
+def _save_figure(fig, path: Path, *, draft_mode: bool = False) -> None:
+    if draft_mode:
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+    else:
+        fig.savefig(path, dpi=300, bbox_inches="tight")
+        fig.savefig(path.with_suffix(".pdf"), bbox_inches="tight")
+    plt.close(fig)
+```
+
+`draft_mode` read from `cfg["output"].get("draft_mode", False)` and threaded
+through all `_save_figure` calls in `run_analysis()`.
+
+---
+
+## Section 2: Table Reorganization
+
+### Target mapping
+
+| File | Directory | Rationale |
+|------|-----------|-----------|
+| `processed_data.csv` | `01_QC_and_Preprocessing/` | Core preprocessed matrix |
+| `sample_labels.csv` | `01_QC_and_Preprocessing/` | Group assignments |
+| `feature_metadata.csv` | `01_QC_and_Preprocessing/` | Feature annotations |
+| `qc_rsd_audit.csv` | `01_QC_and_Preprocessing/` | QC audit trail |
+| `config_used.yaml` | `01_QC_and_Preprocessing/` | Reproducibility record |
+| `pipeline_log.txt` | `01_QC_and_Preprocessing/` | **NEW** — pipeline.log text export |
+| `anova_results.csv` | `03_Feature_Selection/` | ANOVA full results |
+| `volcano_{g1}_vs_{g2}.csv` | `03_Feature_Selection/` | Volcano per-pair results |
+| `roc_{g1}_vs_{g2}.csv` | `04_Biomarker_Validation/` | ROC per-pair results |
+| `rf_importance_{g1}_vs_{g2}.csv` | `05_Supplementary/` | Random Forest importance |
+| `outlier_results.csv` | `05_Supplementary/` | Outlier detection results |
+| `paired_resolution_audit.csv` | `05_Supplementary/` | Paired resolution audit |
+| `significant_features_summary.xlsx` | **Root** | Cross-analysis summary |
+| `Summary.csv` | **Root** | Cross-analysis summary (CSV) |
+
+---
+
+## Section 3: Figure Improvements
+
+### 3a. Global Changes
+
+| Item | Change |
+|------|--------|
+| **Legend placement** | Score plots: `bbox_to_anchor=(1.05, 1)` outside right. Others: fixed position per plot type. Ban `loc="best"`. |
+| **figsize standardization** | Score plots `(8, 8)` 1:1. Side-by-side `(16, 7)` ~2:1. Bar/lollipop: dynamic height. |
+| **Confidence ellipses** | Remove fill entirely. Dashed border only (`linestyle="--"`, `fill=False`). Matches PLS-DA style. |
+
+### 3b. Per-Plot Fixes
+
+#### OPLS-DA Score Plot (`visualization/oplsda_plot.py`)
+- Remove `fill_alpha` from confidence ellipses → dashed border only
+- Confirm `adjustText` label repel is active
+
+#### Heatmap (`visualization/heatmap.py`)
+- When features > 50: hide X-axis tick labels entirely
+- When features <= 50: keep 90-degree vertical labels
+- Threshold constant: `_HEATMAP_XLABEL_THRESHOLD = 50`
+
+#### Outlier Side-by-Side (`visualization/outlier_plot.py`)
+- Change figsize to `(16, 7)` for 2:1 aspect ratio
+- Use `GridSpec` or `constrained_layout` for strict top/bottom alignment
+- `fig.align_ylabels()` to align Y-axis labels
+- Confirm `adjustText` on outlier labels in both subplots
+
+#### ANOVA Boxplot (`ms-core: visualization/anova_plot.py`)
+- Add horizontal jitter to raw data points (stripplot or manual uniform offset)
+- Prevents point overlap when sample counts are high or values are close
+- **Cross-repo**: commit in ms-core first, then update submodule pointer
+
+#### Confusion Matrix (`visualization/rf_plot.py` + `run_from_config.py`)
+- When multiple confusion matrices are generated in the same report,
+  lock `vmin=0` and `vmax=max_count_across_all_pairs`
+- Implementation: `run_from_config.py` collects all RF results first, computes
+  `global_vmax = max(cm.max() for cm in all_confusion_matrices)`, then passes
+  `vmax=global_vmax` to each `plot_confusion_matrix()` call in the rendering pass
+
+#### Volcano Plot (`visualization/volcano_plot.py`)
+- Legend: `loc="best"` → `loc="upper right"`
+
+#### Density Plot (`visualization/density_plot.py`)
+- Legend: `loc="best"` → `loc="upper right"`
+
+#### Boxplot (`visualization/boxplot.py`)
+- Legend: `loc="best"` → `loc="upper left"`
+
+#### S-Plot (`visualization/oplsda_plot.py`)
+- Confirm `adjustText` label repel is active for top-N annotations
+
+#### DModX / PCA Outlier (`visualization/outlier_plot.py`)
+- Confirm `adjustText` label repel is active; fallback to offset if not installed
+
+#### ROC / AUC Ranking
+- No changes needed (already meets publication standards)
+
+---
+
+## Files Changed
+
+### This repo (Metaboanalyst_clone)
+
+| File | Changes |
+|------|---------|
+| `visualization/theme.py` | Add `apply_publication_export_style()` |
+| `visualization/oplsda_plot.py` | Ellipse fill removal, adjustText confirm |
+| `visualization/heatmap.py` | X-axis label auto-hide threshold |
+| `visualization/outlier_plot.py` | 2:1 GridSpec, adjustText confirm |
+| `visualization/volcano_plot.py` | Legend position fix |
+| `visualization/density_plot.py` | Legend position fix |
+| `visualization/boxplot.py` | Legend position fix |
+| `visualization/rf_plot.py` | Confusion matrix vmin/vmax parameter |
+| `scripts/run_from_config.py` | `_save_figure` upgrade, table reorganization, draft_mode, pipeline_log.txt, confusion matrix vmax coordination |
+
+### ms-core (submodule)
+
+| File | Changes |
+|------|---------|
+| `visualization/anova_plot.py` | Add jitter to boxplot data points |
+
+---
+
+## Out of Scope
+
+- GUI-side rendering changes (stays at 150 DPI, DejaVu Sans)
+- Interactive Plotly plot styling (HTML exports unchanged)
+- New plot types
+- Excel formatting/styling changes to `significant_features_summary.xlsx`

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -1246,6 +1246,10 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     rf_trees = int(rf_cfg.get("n_trees", 500))
     rf_cv_folds = int(rf_cfg.get("cv_folds", 5))
     rf_top_n = int(rf_cfg.get("top_n", 25))
+
+    # Pass 1: collect RF results and find global vmax for confusion matrices
+    rf_results: list[tuple[str, str, Any]] = []
+    global_cm_vmax = 0
     for g1, g2 in report_pairs:
         print(f"  RF {g1} vs {g2}...")
         try:
@@ -1263,37 +1267,44 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 cv_folds=rf_cv_folds,
                 top_n=rf_top_n,
             )
-            rf_result.feature_importance.to_csv(
-                os.path.join(
-                    report_dirs["supplementary"], f"rf_importance_{g1}_vs_{g2}.csv"
-                ),
-                index=False,
-            )
-
-            fig = plt.figure(figsize=(8, 6))
-            plot_rf_importance(rf_result, top_n=rf_top_n, fig=fig)
-            _save_figure(
-                fig,
-                report_dirs["supplementary"] / f"rf_importance_{g1}_vs_{g2}.png",
-                draft_mode=draft_mode,
-            )
-
-            fig = plt.figure(figsize=(6, 5))
-            plot_confusion_matrix(rf_result, fig=fig)
-            _save_figure(
-                fig,
-                report_dirs["supplementary"] / f"rf_confusion_matrix_{g1}_vs_{g2}.png",
-                draft_mode=draft_mode,
-            )
-
-            print(
-                f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_importance_{g1}_vs_{g2}.png"
-            )
-            print(
-                f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_confusion_matrix_{g1}_vs_{g2}.png"
-            )
+            rf_results.append((g1, g2, rf_result))
+            global_cm_vmax = max(global_cm_vmax, int(rf_result.confusion_mat.max()))
         except Exception as e:
             print(f"    Error: {e}")
+
+    # Pass 2: render figures with unified color scale
+    for g1, g2, rf_result in rf_results:
+        rf_result.feature_importance.to_csv(
+            os.path.join(
+                report_dirs["supplementary"], f"rf_importance_{g1}_vs_{g2}.csv"
+            ),
+            index=False,
+        )
+
+        fig = plt.figure(figsize=(8, 6))
+        plot_rf_importance(rf_result, top_n=rf_top_n, fig=fig)
+        _save_figure(
+            fig,
+            report_dirs["supplementary"] / f"rf_importance_{g1}_vs_{g2}.png",
+            draft_mode=draft_mode,
+        )
+
+        fig = plt.figure(figsize=(6, 5))
+        plot_confusion_matrix(
+            rf_result, fig=fig, vmax=global_cm_vmax if len(rf_results) > 1 else None
+        )
+        _save_figure(
+            fig,
+            report_dirs["supplementary"] / f"rf_confusion_matrix_{g1}_vs_{g2}.png",
+            draft_mode=draft_mode,
+        )
+
+        print(
+            f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_importance_{g1}_vs_{g2}.png"
+        )
+        print(
+            f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_confusion_matrix_{g1}_vs_{g2}.png"
+        )
 
     if paired_resolution_audit_rows:
         audit_path = os.path.join(

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -753,23 +753,28 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     paired_resolution_audit_rows: list[dict[str, Any]] = []
 
     # Save processed data
-    processed.to_csv(os.path.join(output_dir, "processed_data.csv"))
-    final_labels.to_csv(os.path.join(output_dir, "sample_labels.csv"))
+    processed.to_csv(os.path.join(report_dirs["qc"], "processed_data.csv"))
+    final_labels.to_csv(os.path.join(report_dirs["qc"], "sample_labels.csv"))
     final_feature_metadata.to_csv(
-        os.path.join(output_dir, "feature_metadata.csv"),
+        os.path.join(report_dirs["qc"], "feature_metadata.csv"),
         index_label="Feature",
     )
     qc_rsd_audit = pipeline.step_feature_metadata.get("qc_rsd")
     if qc_rsd_audit is not None and not qc_rsd_audit.empty:
         qc_rsd_audit.to_csv(
-            os.path.join(output_dir, "qc_rsd_audit.csv"),
+            os.path.join(report_dirs["qc"], "qc_rsd_audit.csv"),
             index_label="Feature",
         )
 
     # Save a copy of the config used
-    config_copy_path = os.path.join(output_dir, "config_used.yaml")
+    config_copy_path = os.path.join(report_dirs["qc"], "config_used.yaml")
     with open(config_copy_path, "w", encoding="utf-8") as f:
         f.write(dump_yaml(cfg, include_runtime=False))
+
+    log_path = os.path.join(report_dirs["qc"], "pipeline_log.txt")
+    with open(log_path, "w", encoding="utf-8") as f:
+        for line in pipeline.log:
+            f.write(line + "\n")
     print(f"  Saved to {output_dir}")
 
     # ── QC / preprocessing report ────────────────────────
@@ -778,7 +783,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
     fig = plt.figure(figsize=(12, 8))
     plot_norm_comparison(pre_norm_matrix, processed, final_labels, fig=fig)
-    _save_figure(fig, report_dirs["qc"] / "normalization_comparison.png", draft_mode=draft_mode)
+    _save_figure(
+        fig, report_dirs["qc"] / "normalization_comparison.png", draft_mode=draft_mode
+    )
     print(f"  Saved {REPORT_SUBDIRS['qc']}\\normalization_comparison.png")
 
     # ── PCA ───────────────────────────────────────────────
@@ -819,7 +826,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
         anova_result.result_df, final_feature_metadata
     )
     anova_result.result_df.to_csv(
-        os.path.join(output_dir, "anova_results.csv"), index=False
+        os.path.join(report_dirs["feature"], "anova_results.csv"), index=False
     )
 
     # Collect full ANOVA table for Excel export and summary scoring.
@@ -837,7 +844,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
     fig = plt.figure(figsize=(10, 8))
     plot_anova_importance(anova_result, top_n=25, fig=fig)
-    _save_figure(fig, report_dirs["feature"] / "anova_importance.png", draft_mode=draft_mode)
+    _save_figure(
+        fig, report_dirs["feature"] / "anova_importance.png", draft_mode=draft_mode
+    )
 
     anova_ranked = anova_result.result_df.sort_values("pvalue_adj").copy()
     anova_feature_pool = anova_ranked["Feature"].tolist()
@@ -858,7 +867,11 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             max_features=min(int(heatmap_cfg.get("max_features", 50)), 50),
             top_by=str(heatmap_cfg.get("top_by", "var")),
         )
-        _save_figure(heatmap_fig, report_dirs["global"] / "heatmap_top50.png", draft_mode=draft_mode)
+        _save_figure(
+            heatmap_fig,
+            report_dirs["global"] / "heatmap_top50.png",
+            draft_mode=draft_mode,
+        )
         print(f"  Saved {REPORT_SUBDIRS['global']}\\heatmap_top50.png")
 
     anova_pairs = report_pairs
@@ -1117,7 +1130,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 vresult.result_df, final_feature_metadata
             )
             vresult.result_df.to_csv(
-                os.path.join(output_dir, f"volcano_{g1}_vs_{g2}.csv"),
+                os.path.join(report_dirs["feature"], f"volcano_{g1}_vs_{g2}.csv"),
                 index=False,
             )
 
@@ -1130,7 +1143,11 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 _excel_sheets[f"Volcano_{g1}_vs_{g2}"] = vol_sig
             fig = plt.figure(figsize=(10, 8))
             plot_volcano(vresult, fig=fig)
-            _save_figure(fig, report_dirs["feature"] / f"volcano_{g1}_vs_{g2}.png", draft_mode=draft_mode)
+            _save_figure(
+                fig,
+                report_dirs["feature"] / f"volcano_{g1}_vs_{g2}.png",
+                draft_mode=draft_mode,
+            )
             print(f"    Saved {REPORT_SUBDIRS['feature']}\\volcano_{g1}_vs_{g2}.png")
         except Exception as e:
             print(f"    Error: {e}")
@@ -1162,13 +1179,17 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 cv_folds=roc_cv_folds,
             )
             roc_result.summary_df.to_csv(
-                os.path.join(output_dir, f"roc_{g1}_vs_{g2}.csv"),
+                os.path.join(report_dirs["validation"], f"roc_{g1}_vs_{g2}.csv"),
                 index=False,
             )
 
             fig = plt.figure(figsize=(8, 6))
             plot_roc_curves(roc_result, fig=fig)
-            _save_figure(fig, report_dirs["validation"] / f"roc_{g1}_vs_{g2}.png", draft_mode=draft_mode)
+            _save_figure(
+                fig,
+                report_dirs["validation"] / f"roc_{g1}_vs_{g2}.png",
+                draft_mode=draft_mode,
+            )
 
             fig = plt.figure(figsize=(8, 6))
             plot_auc_ranking(roc_result, fig=fig)
@@ -1196,17 +1217,23 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             alpha=float(outlier_cfg.get("alpha", 0.05)),
         )
         outlier_result.get_outlier_df().to_csv(
-            os.path.join(output_dir, "outlier_results.csv"),
+            os.path.join(report_dirs["supplementary"], "outlier_results.csv"),
             index=False,
         )
 
         fig = plt.figure(figsize=(8, 6))
         plot_outlier_score(outlier_result, labels=final_labels, fig=fig)
-        _save_figure(fig, report_dirs["supplementary"] / "outlier_t2.png", draft_mode=draft_mode)
+        _save_figure(
+            fig, report_dirs["supplementary"] / "outlier_t2.png", draft_mode=draft_mode
+        )
 
         fig = plt.figure(figsize=(8, 6))
         plot_dmodx(outlier_result, labels=final_labels, fig=fig)
-        _save_figure(fig, report_dirs["supplementary"] / "outlier_dmodx.png", draft_mode=draft_mode)
+        _save_figure(
+            fig,
+            report_dirs["supplementary"] / "outlier_dmodx.png",
+            draft_mode=draft_mode,
+        )
         print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_t2.png")
         print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_dmodx.png")
     except Exception as e:
@@ -1237,7 +1264,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 top_n=rf_top_n,
             )
             rf_result.feature_importance.to_csv(
-                os.path.join(output_dir, f"rf_importance_{g1}_vs_{g2}.csv"),
+                os.path.join(
+                    report_dirs["supplementary"], f"rf_importance_{g1}_vs_{g2}.csv"
+                ),
                 index=False,
             )
 
@@ -1267,7 +1296,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             print(f"    Error: {e}")
 
     if paired_resolution_audit_rows:
-        audit_path = os.path.join(output_dir, "paired_resolution_audit.csv")
+        audit_path = os.path.join(
+            report_dirs["supplementary"], "paired_resolution_audit.csv"
+        )
         pd.DataFrame(paired_resolution_audit_rows).to_csv(audit_path, index=False)
         print(f"  Saved {audit_path}")
 

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -22,6 +22,7 @@ _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, _PROJECT_ROOT)
 
 import matplotlib  # noqa: E402
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
@@ -41,7 +42,11 @@ from core.input_resolver import (  # noqa: E402
 )
 from core.pipeline import MetaboAnalystPipeline  # noqa: E402
 from core.sample_interface import identify_sample_columns  # noqa: E402
-from core.sample_info import read_sample_info_sheet, build_aligned_factors, extract_subject_ids  # noqa: E402
+from core.sample_info import (
+    read_sample_info_sheet,
+    build_aligned_factors,
+    extract_subject_ids,
+)  # noqa: E402
 from analysis.outlier import run_outlier_detection  # noqa: E402
 from analysis.random_forest import run_random_forest  # noqa: E402
 from analysis.roc import run_roc_analysis  # noqa: E402
@@ -89,23 +94,33 @@ def _ensure_report_dirs(output_dir: str) -> dict[str, Path]:
     return report_dirs
 
 
-def _save_figure(fig: Any, path: Path) -> None:
-    """Save a matplotlib-compatible figure and close it."""
-    fig.savefig(path, dpi=150, bbox_inches="tight")
+def _save_figure(fig: Any, path: Path, *, draft_mode: bool = False) -> None:
+    """Save a matplotlib figure as PNG (and PDF in publication mode), then close."""
+    if draft_mode:
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+    else:
+        fig.savefig(path, dpi=300, bbox_inches="tight")
+        fig.savefig(path.with_suffix(".pdf"), bbox_inches="tight")
     plt.close(fig)
 
 
 def _iter_output_files(output_dir: str) -> Iterable[Path]:
     """Yield every file under the output directory in stable relative order."""
     root = Path(output_dir)
-    yield from sorted((path for path in root.rglob("*") if path.is_file()), key=lambda path: str(path.relative_to(root)))
+    yield from sorted(
+        (path for path in root.rglob("*") if path.is_file()),
+        key=lambda path: str(path.relative_to(root)),
+    )
 
 
 # ── Config loader ─────────────────────────────────────────
 
+
 def load_config(path: str) -> dict:
     """Load and validate a YAML configuration file."""
-    return load_yaml_config(path, require_required_sections=True).to_dict(include_runtime=True)
+    return load_yaml_config(path, require_required_sections=True).to_dict(
+        include_runtime=True
+    )
 
 
 def parse_pair_config(
@@ -129,7 +144,9 @@ def parse_pair_config(
     return result
 
 
-def unique_group_pairs(parsed_pairs: list[tuple[str, str, bool]]) -> list[tuple[str, str]]:
+def unique_group_pairs(
+    parsed_pairs: list[tuple[str, str, bool]],
+) -> list[tuple[str, str]]:
     """Return de-duplicated ordered group pairs while ignoring paired-mode metadata."""
     seen: set[tuple[str, str]] = set()
     unique_pairs: list[tuple[str, str]] = []
@@ -144,9 +161,13 @@ def unique_group_pairs(parsed_pairs: list[tuple[str, str, bool]]) -> list[tuple[
 
 def resolve_volcano_test_mode(volcano_cfg: Mapping[str, Any]) -> tuple[str, bool, bool]:
     """Return (test_key, equal_var, nonpar) for volcano analysis."""
-    test_key = str(
-        volcano_cfg.get("test", volcano_cfg.get("parametric_test_default", "welch"))
-    ).strip().lower()
+    test_key = (
+        str(
+            volcano_cfg.get("test", volcano_cfg.get("parametric_test_default", "welch"))
+        )
+        .strip()
+        .lower()
+    )
     if test_key not in {"student", "welch", "wilcoxon"}:
         test_key = "welch"
     return test_key, test_key == "student", test_key == "wilcoxon"
@@ -163,7 +184,9 @@ def resolve_top_vip(plsda_cfg: Mapping[str, Any]) -> int:
     return max(1, int(plsda_cfg.get("top_vip", 15)))
 
 
-def resolve_volcano_fc_threshold(volcano_cfg: Mapping[str, Any]) -> tuple[float, float | None]:
+def resolve_volcano_fc_threshold(
+    volcano_cfg: Mapping[str, Any],
+) -> tuple[float, float | None]:
     """Return volcano FC thresholds while supporting legacy log2-only configs."""
     fc_thresh = volcano_cfg.get("fc_thresh")
     log2_fc_thresh = volcano_cfg.get("log2_fc_thresh")
@@ -176,12 +199,17 @@ def resolve_volcano_fc_threshold(volcano_cfg: Mapping[str, Any]) -> tuple[float,
 
 # ── Data loaders ──────────────────────────────────────────
 
+
 def _annotate_feature_table(
     df: pd.DataFrame,
     feature_metadata: pd.DataFrame | None,
     feature_column: str = "Feature",
 ) -> pd.DataFrame:
-    if feature_metadata is None or feature_metadata.empty or feature_column not in df.columns:
+    if (
+        feature_metadata is None
+        or feature_metadata.empty
+        or feature_column not in df.columns
+    ):
         return df
 
     meta = feature_metadata.copy()
@@ -198,7 +226,9 @@ def load_data(cfg: dict) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
     input_cfg = cfg["input"]
     input_file = input_cfg["file"]
     if not input_file:
-        raise ValueError("No input file specified. Use --input <path> on the command line.")
+        raise ValueError(
+            "No input file specified. Use --input <path> on the command line."
+        )
     fmt = input_cfg.get("format", "sample_type_row")
     is_excel_input = Path(input_file).suffix.lower() in {".xlsx", ".xls"}
 
@@ -222,11 +252,17 @@ def load_data(cfg: dict) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
         id_values = raw[feature_col].astype(str)
         group_rows = raw[id_values == str(sample_type_key)]
         if group_rows.empty:
-            raise ValueError("Sample_Type row could not be resolved from the selected worksheet.")
+            raise ValueError(
+                "Sample_Type row could not be resolved from the selected worksheet."
+            )
         if len(group_rows) > 1:
-            raise ValueError("Sample_Type row must be unique in the selected worksheet.")
+            raise ValueError(
+                "Sample_Type row must be unique in the selected worksheet."
+            )
         sample_type_row = group_rows.iloc[0]
-        valid_sample_cols = [col for col in sample_columns if pd.notna(sample_type_row.get(col))]
+        valid_sample_cols = [
+            col for col in sample_columns if pd.notna(sample_type_row.get(col))
+        ]
         feature_rows = raw[id_values != str(sample_type_key)].copy()
         feature_names = pd.Index(feature_rows[feature_col].astype(str), name="Feature")
         sample_types = sample_type_row.loc[valid_sample_cols].values
@@ -243,7 +279,9 @@ def load_data(cfg: dict) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
                 sample_info,
                 observed_label_name="Worksheet Sample_Type",
             )
-        feature_metadata = extract_feature_metadata(feature_rows.reset_index(drop=True), feature_names)
+        feature_metadata = extract_feature_metadata(
+            feature_rows.reset_index(drop=True), feature_names
+        )
 
     elif fmt == "plain":
         # All rows are features; groups inferred from column names
@@ -253,15 +291,20 @@ def load_data(cfg: dict) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
         data = raw.loc[:, sample_columns].values.T
         data = pd.DataFrame(data, columns=feature_names, index=sample_names)
         data = data.apply(pd.to_numeric, errors="coerce")
-        feature_metadata = extract_feature_metadata(raw.reset_index(drop=True), feature_names)
+        feature_metadata = extract_feature_metadata(
+            raw.reset_index(drop=True), feature_names
+        )
         if sample_info is not None:
-            labels = build_labels_from_sample_info(data.index, sample_info, label_name="Group")
+            labels = build_labels_from_sample_info(
+                data.index, sample_info, label_name="Group"
+            )
         elif input_cfg.get("plain_label_mode") == "column_names":
             labels = pd.Series(sample_names, index=sample_names, name="Group")
         else:
             labels = pd.Series(
                 [infer_group_from_sample_name(n) for n in sample_names],
-                index=sample_names, name="Group",
+                index=sample_names,
+                name="Group",
             )
 
         # Drop excluded samples
@@ -272,7 +315,9 @@ def load_data(cfg: dict) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
             data = data.loc[~exclude_mask]
             labels = labels.loc[~exclude_mask]
     else:
-        raise ValueError(f"Unknown input format: '{fmt}'. Use 'sample_type_row' or 'plain'.")
+        raise ValueError(
+            f"Unknown input format: '{fmt}'. Use 'sample_type_row' or 'plain'."
+        )
 
     if sample_info is not None:
         validate_sample_info_alignment(data.index, sample_info)
@@ -344,7 +389,11 @@ def _select_heatmap_matrix(
     else:
         significant = ranked.iloc[0:0]
     feature_rows = significant if not significant.empty else ranked
-    feature_names = [feat for feat in feature_rows["Feature"].astype(str).tolist() if feat in df.columns]
+    feature_names = [
+        feat
+        for feat in feature_rows["Feature"].astype(str).tolist()
+        if feat in df.columns
+    ]
     selected = feature_names[:feature_cap]
     if selected:
         return df.loc[:, selected].copy()
@@ -353,8 +402,11 @@ def _select_heatmap_matrix(
 
 # ── Significant features Excel export ────────────────────
 
+
 def _export_significant_features_excel(
-    sheets: dict, output_dir: str, top_n: int | None = None,
+    sheets: dict,
+    output_dir: str,
+    top_n: int | None = None,
 ):
     """
     Write a consolidated Excel workbook with significant features from all analyses.
@@ -369,7 +421,8 @@ def _export_significant_features_excel(
     excel_path = os.path.join(output_dir, "significant_features_summary.xlsx")
     summary_csv_path = os.path.join(output_dir, "Summary.csv")
     summary_sheet_filter = {
-        sheet_name: df for sheet_name, df in sheets.items()
+        sheet_name: df
+        for sheet_name, df in sheets.items()
         if "oplsda" not in sheet_name.lower()
     }
     feature_tags: dict[str, bool] = {}
@@ -443,7 +496,11 @@ def _export_significant_features_excel(
         name = sheet_name.lower()
         if "vip" in name and pd.notna(row.get("VIP")):
             return f"VIP={float(row['VIP']):.2f}"
-        if "volcano" in name and pd.notna(row.get("pvalue_adj")) and pd.notna(row.get("log2FC")):
+        if (
+            "volcano" in name
+            and pd.notna(row.get("pvalue_adj"))
+            and pd.notna(row.get("log2FC"))
+        ):
             return f"p_adj={float(row['pvalue_adj']):.2e};log2FC={float(row['log2FC']):.2f}"
         if "anova" in name and pd.notna(row.get("pvalue_adj")):
             return f"p_adj={float(row['pvalue_adj']):.2e}"
@@ -481,7 +538,9 @@ def _export_significant_features_excel(
 
     # Build summary DataFrame
     all_sheet_names = [
-        s for s in summary_sheet_filter.keys() if "Feature" in summary_sheet_filter[s].columns
+        s
+        for s in summary_sheet_filter.keys()
+        if "Feature" in summary_sheet_filter[s].columns
     ]
     summary_rows = []
     for feat in sorted(all_features):
@@ -533,11 +592,14 @@ def _export_significant_features_excel(
         print(f"  Saved {summary_csv_path}")
     print(f"  Sheets: {', '.join(['Summary'] + list(sheets.keys()))}")
     scope_text = "all rows" if top_n in (None, 0) else f"top {top_n} each"
-    print(f"  Summary: {len(summary_df)} unique features across "
-          f"{len(all_sheet_names)} analyses ({scope_text})")
+    print(
+        f"  Summary: {len(summary_df)} unique features across "
+        f"{len(all_sheet_names)} analyses ({scope_text})"
+    )
 
 
 # ── Main analysis ─────────────────────────────────────────
+
 
 def run_analysis(cfg: dict) -> dict[str, str]:
     """Execute the full analysis pipeline from a config dict."""
@@ -551,12 +613,20 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     input_stem = os.path.splitext(os.path.basename(cfg["input"]["file"]))[0]
     base_suffix = cfg["output"].get("suffix", "")
     auto_timestamp = bool(cfg["output"].get("auto_timestamp", True))
-    resolved_suffix = compose_output_suffix(base_suffix, include_timestamp=auto_timestamp)
+    resolved_suffix = compose_output_suffix(
+        base_suffix, include_timestamp=auto_timestamp
+    )
     cfg["output"]["base_suffix"] = base_suffix
     cfg["output"]["suffix"] = resolved_suffix
     output_dir = os.path.join(results_root, input_stem + resolved_suffix)
     os.makedirs(output_dir, exist_ok=True)
     report_dirs = _ensure_report_dirs(output_dir)
+
+    draft_mode = bool(cfg.get("output", {}).get("draft_mode", False))
+    if not draft_mode:
+        from visualization.theme import apply_publication_export_style
+
+        apply_publication_export_style()
 
     # ── Build SpecNorm factors if needed ──────────────────
     factors = None
@@ -604,10 +674,14 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     print("\nPipeline log:")
     for line in pipeline.log:
         print(f"  {line}")
-    print(f"\nProcessed data: {processed.shape[0]} samples x {processed.shape[1]} features")
+    print(
+        f"\nProcessed data: {processed.shape[0]} samples x {processed.shape[1]} features"
+    )
 
     included_groups = cfg["groups"].get("include", [])
-    final_labels = pipeline.processed_labels if pipeline.processed_labels is not None else labels
+    final_labels = (
+        pipeline.processed_labels if pipeline.processed_labels is not None else labels
+    )
     final_feature_metadata = (
         pipeline.processed_feature_metadata
         if pipeline.processed_feature_metadata is not None
@@ -627,27 +701,45 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     feat_std = processed.std()
     zero_var_feats = feat_std[feat_std == 0].index.tolist()
     if zero_var_feats:
-        print(f"  Dropping {len(zero_var_feats)} zero-variance features (constant after QC removal)")
+        print(
+            f"  Dropping {len(zero_var_feats)} zero-variance features (constant after QC removal)"
+        )
 
-    processed, final_labels = _finalize_analysis_matrix(processed, final_labels, included_groups)
+    processed, final_labels = _finalize_analysis_matrix(
+        processed, final_labels, included_groups
+    )
     final_feature_metadata = final_feature_metadata.reindex(processed.columns).copy()
     volcano_matrix, _ = _finalize_analysis_matrix(
         pipeline.steps["transformed"].copy(),
-        (pipeline.processed_labels if pipeline.processed_labels is not None else labels).copy(),
+        (
+            pipeline.processed_labels
+            if pipeline.processed_labels is not None
+            else labels
+        ).copy(),
         included_groups,
     )
     anova_matrix = volcano_matrix.copy()
     volcano_fc_matrix, _ = _finalize_analysis_matrix(
         pipeline.steps["row_normed"].copy(),
-        (pipeline.processed_labels if pipeline.processed_labels is not None else labels).copy(),
+        (
+            pipeline.processed_labels
+            if pipeline.processed_labels is not None
+            else labels
+        ).copy(),
         included_groups,
     )
     pre_norm_matrix, _ = _finalize_analysis_matrix(
         pipeline.steps["filtered"].copy(),
-        (pipeline.processed_labels if pipeline.processed_labels is not None else labels).copy(),
+        (
+            pipeline.processed_labels
+            if pipeline.processed_labels is not None
+            else labels
+        ).copy(),
         included_groups,
     )
-    pre_norm_matrix = pre_norm_matrix.reindex(index=processed.index, columns=processed.columns)
+    pre_norm_matrix = pre_norm_matrix.reindex(
+        index=processed.index, columns=processed.columns
+    )
 
     raw_volcano_pairs = parse_pair_config(cfg["groups"].get("volcano_pairs", []))
     raw_oplsda_pairs = parse_pair_config(cfg["groups"].get("oplsda_pairs", []))
@@ -686,7 +778,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
     fig = plt.figure(figsize=(12, 8))
     plot_norm_comparison(pre_norm_matrix, processed, final_labels, fig=fig)
-    _save_figure(fig, report_dirs["qc"] / "normalization_comparison.png")
+    _save_figure(fig, report_dirs["qc"] / "normalization_comparison.png", draft_mode=draft_mode)
     print(f"  Saved {REPORT_SUBDIRS['qc']}\\normalization_comparison.png")
 
     # ── PCA ───────────────────────────────────────────────
@@ -695,12 +787,14 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     n_comp = analysis_cfg["pca"]["n_components"]
     pca_result = run_pca(processed, final_labels, n_components=n_comp)
     evr = pca_result.explained_variance_ratio
-    print(f"  Variance explained (PC1-{min(n_comp,5)}): "
-          f"{[f'{v*100:.1f}%' for v in evr[:5]]}")
+    print(
+        f"  Variance explained (PC1-{min(n_comp, 5)}): "
+        f"{[f'{v * 100:.1f}%' for v in evr[:5]]}"
+    )
 
     fig = plt.figure(figsize=(10, 8))
     plot_pca_score(pca_result, pc_x=0, pc_y=1, fig=fig)
-    _save_figure(fig, report_dirs["qc"] / "pca_score_plot.png")
+    _save_figure(fig, report_dirs["qc"] / "pca_score_plot.png", draft_mode=draft_mode)
     print(f"  Saved {REPORT_SUBDIRS['qc']}\\pca_score_plot.png")
 
     # ── ANOVA ─────────────────────────────────────────────
@@ -709,35 +803,41 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     group_list = sorted(final_labels.unique())
     print(f"Running ANOVA ({' vs '.join(group_list)})...")
     anova_result = run_anova(
-        anova_matrix, final_labels,
+        anova_matrix,
+        final_labels,
         p_thresh=anova_cfg["p_thresh"],
         nonpar=anova_cfg["nonpar"],
         use_fdr=anova_cfg["use_fdr"],
         posthoc=anova_cfg["posthoc"],
     )
-    print(f"  Significant (FDR < {anova_cfg['p_thresh']}): "
-          f"{anova_result.n_significant} / {len(anova_result.result_df)}")
+    print(
+        f"  Significant (FDR < {anova_cfg['p_thresh']}): "
+        f"{anova_result.n_significant} / {len(anova_result.result_df)}"
+    )
 
-    anova_result.result_df = _annotate_feature_table(anova_result.result_df, final_feature_metadata)
-    anova_result.result_df.to_csv(os.path.join(output_dir, "anova_results.csv"), index=False)
+    anova_result.result_df = _annotate_feature_table(
+        anova_result.result_df, final_feature_metadata
+    )
+    anova_result.result_df.to_csv(
+        os.path.join(output_dir, "anova_results.csv"), index=False
+    )
 
     # Collect full ANOVA table for Excel export and summary scoring.
-    _anova_sig = (anova_result.result_df
-                  .sort_values("pvalue_adj")
-                  [[
-                      "Feature",
-                      "pvalue",
-                      "pvalue_adj",
-                      "neg_log10p",
-                      "significant",
-                      FEATURE_MARKER_COLUMN,
-                  ]]
-                  .copy())
+    _anova_sig = anova_result.result_df.sort_values("pvalue_adj")[
+        [
+            "Feature",
+            "pvalue",
+            "pvalue_adj",
+            "neg_log10p",
+            "significant",
+            FEATURE_MARKER_COLUMN,
+        ]
+    ].copy()
     _excel_sheets["ANOVA_All"] = _anova_sig
 
     fig = plt.figure(figsize=(10, 8))
     plot_anova_importance(anova_result, top_n=25, fig=fig)
-    _save_figure(fig, report_dirs["feature"] / "anova_importance.png")
+    _save_figure(fig, report_dirs["feature"] / "anova_importance.png", draft_mode=draft_mode)
 
     anova_ranked = anova_result.result_df.sort_values("pvalue_adj").copy()
     anova_feature_pool = anova_ranked["Feature"].tolist()
@@ -758,7 +858,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             max_features=min(int(heatmap_cfg.get("max_features", 50)), 50),
             top_by=str(heatmap_cfg.get("top_by", "var")),
         )
-        _save_figure(heatmap_fig, report_dirs["global"] / "heatmap_top50.png")
+        _save_figure(heatmap_fig, report_dirs["global"] / "heatmap_top50.png", draft_mode=draft_mode)
         print(f"  Saved {REPORT_SUBDIRS['global']}\\heatmap_top50.png")
 
     anova_pairs = report_pairs
@@ -771,7 +871,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
         if pair_data.empty or pair_labels.nunique() < 2:
             continue
 
-        candidate_features = sig_feature_pool if sig_feature_pool else anova_feature_pool
+        candidate_features = (
+            sig_feature_pool if sig_feature_pool else anova_feature_pool
+        )
         pair_means = pair_data.groupby(pair_labels).mean(numeric_only=True)
         if g1 not in pair_means.index or g2 not in pair_means.index:
             continue
@@ -788,6 +890,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             _save_figure(
                 fig,
                 report_dirs["supplementary"] / f"anova_boxplot_{g1}_vs_{g2}_top{i}.png",
+                draft_mode=draft_mode,
             )
             saved_anova_boxplots += 1
     print(f"  Saved {REPORT_SUBDIRS['feature']}\\anova_importance.png")
@@ -814,8 +917,14 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             all_plsda_result = run_plsda(processed, final_labels, n_components=n_comp)
             fig = plt.figure(figsize=(8, 6))
             plot_plsda_score(all_plsda_result, fig=fig)
-            _save_figure(fig, report_dirs["supplementary"] / "plsda_score_all_groups.png")
-            print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\plsda_score_all_groups.png")
+            _save_figure(
+                fig,
+                report_dirs["supplementary"] / "plsda_score_all_groups.png",
+                draft_mode=draft_mode,
+            )
+            print(
+                f"  Saved {REPORT_SUBDIRS['supplementary']}\\plsda_score_all_groups.png"
+            )
         except Exception as e:
             print(f"  All-group PLS-DA error: {e}")
 
@@ -827,19 +936,34 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 pair_labels = final_labels.loc[pair_mask]
 
                 plsda_result = run_plsda(pair_data, pair_labels, n_components=n_comp)
-                print(f"    VIP range: {plsda_result.vips.min():.2f} - "
-                      f"{plsda_result.vips.max():.2f}")
+                print(
+                    f"    VIP range: {plsda_result.vips.min():.2f} - "
+                    f"{plsda_result.vips.max():.2f}"
+                )
 
                 # Collect VIP scores for Excel export
-                vip_df = _annotate_feature_table(plsda_result.get_vip_df(), final_feature_metadata)
+                vip_df = _annotate_feature_table(
+                    plsda_result.get_vip_df(), final_feature_metadata
+                )
                 vip_df.insert(0, "Rank", range(1, len(vip_df) + 1))
                 _excel_sheets[f"VIP_{g1}_vs_{g2}"] = vip_df
 
                 fig = plt.figure(figsize=(10, max(6, top_vip * 0.32)))
-                plot_vip(plsda_result, top_n=top_vip,
-                         data=pair_data, labels=pair_labels, fig=fig)
-                _save_figure(fig, report_dirs["feature"] / f"plsda_vip_{g1}_vs_{g2}.png")
-                print(f"    Saved {REPORT_SUBDIRS['feature']}\\plsda_vip_{g1}_vs_{g2}.png")
+                plot_vip(
+                    plsda_result,
+                    top_n=top_vip,
+                    data=pair_data,
+                    labels=pair_labels,
+                    fig=fig,
+                )
+                _save_figure(
+                    fig,
+                    report_dirs["feature"] / f"plsda_vip_{g1}_vs_{g2}.png",
+                    draft_mode=draft_mode,
+                )
+                print(
+                    f"    Saved {REPORT_SUBDIRS['feature']}\\plsda_vip_{g1}_vs_{g2}.png"
+                )
             except Exception as e:
                 print(f"    Error: {e}")
 
@@ -864,11 +988,15 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 pair_labels = final_labels.loc[pair_mask]
 
                 oplsda_result = run_oplsda(pair_data, pair_labels)
-                print(f"    R2Y={oplsda_result.r2y:.3f}, Q2={oplsda_result.q2:.3f}, "
-                      f"backend={oplsda_result.backend}")
+                print(
+                    f"    R2Y={oplsda_result.r2y:.3f}, Q2={oplsda_result.q2:.3f}, "
+                    f"backend={oplsda_result.backend}"
+                )
 
                 # Collect OPLS-DA loadings for Excel export
-                imp_df = _annotate_feature_table(oplsda_result.get_importance_df(), final_feature_metadata)
+                imp_df = _annotate_feature_table(
+                    oplsda_result.get_importance_df(), final_feature_metadata
+                )
                 if not imp_df.empty:
                     imp_df.insert(0, "Rank", range(1, len(imp_df) + 1))
                     _excel_sheets[f"OPLSDA_{g1}_vs_{g2}"] = imp_df
@@ -876,14 +1004,26 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 # Score plot
                 fig = plt.figure(figsize=(8, 6))
                 plot_oplsda_score(oplsda_result, fig=fig)
-                _save_figure(fig, report_dirs["feature"] / f"oplsda_score_{g1}_vs_{g2}.png")
+                _save_figure(
+                    fig,
+                    report_dirs["feature"] / f"oplsda_score_{g1}_vs_{g2}.png",
+                    draft_mode=draft_mode,
+                )
 
                 fig = plt.figure(figsize=(8, 6))
                 plot_oplsda_splot(oplsda_result, top_n=10, fig=fig)
-                _save_figure(fig, report_dirs["feature"] / f"oplsda_splot_{g1}_vs_{g2}.png")
+                _save_figure(
+                    fig,
+                    report_dirs["feature"] / f"oplsda_splot_{g1}_vs_{g2}.png",
+                    draft_mode=draft_mode,
+                )
 
-                print(f"    Saved {REPORT_SUBDIRS['feature']}\\oplsda_score_{g1}_vs_{g2}.png")
-                print(f"    Saved {REPORT_SUBDIRS['feature']}\\oplsda_splot_{g1}_vs_{g2}.png")
+                print(
+                    f"    Saved {REPORT_SUBDIRS['feature']}\\oplsda_score_{g1}_vs_{g2}.png"
+                )
+                print(
+                    f"    Saved {REPORT_SUBDIRS['feature']}\\oplsda_splot_{g1}_vs_{g2}.png"
+                )
             except Exception as e:
                 print(f"    Error: {e}")
 
@@ -894,7 +1034,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
     vol_cfg = analysis_cfg["volcano"]
     volcano_pairs = raw_volcano_pairs
-    volcano_test_key, volcano_equal_var, volcano_nonpar = resolve_volcano_test_mode(vol_cfg)
+    volcano_test_key, volcano_equal_var, volcano_nonpar = resolve_volcano_test_mode(
+        vol_cfg
+    )
     volcano_fc_thresh, volcano_log2_fc_thresh = resolve_volcano_fc_threshold(vol_cfg)
     paired_resolution_cfg = cfg["groups"].get("paired_resolution")
 
@@ -905,8 +1047,10 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     if has_any_paired:
         subject_ids = extract_subject_ids(processed.index, pattern=pair_id_pattern)
         n_with_id = (subject_ids != "").sum()
-        print(f"  Subject IDs extracted: {n_with_id}/{len(subject_ids)} "
-              f"(pattern: {pair_id_pattern})")
+        print(
+            f"  Subject IDs extracted: {n_with_id}/{len(subject_ids)} "
+            f"(pattern: {pair_id_pattern})"
+        )
 
     for g1, g2, is_paired in volcano_pairs:
         test_label = "paired" if is_paired else "unpaired"
@@ -915,8 +1059,10 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             if volcano_nonpar:
                 print(f"    Configured volcano test: {volcano_test_key}")
             vresult = volcano_analysis(
-                volcano_matrix, final_labels,
-                group1=g1, group2=g2,
+                volcano_matrix,
+                final_labels,
+                group1=g1,
+                group2=g2,
                 fc_thresh=volcano_fc_thresh,
                 log2_fc_thresh=volcano_log2_fc_thresh,
                 p_thresh=vol_cfg["p_thresh"],
@@ -930,10 +1076,14 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             )
             pair_info = f", Pairs: {vresult.n_pairs}" if is_paired else ""
             print(f"    Method: {vresult.test_label}")
-            print(f"    Significant: {vresult.n_significant} "
-                  f"(Up: {vresult.n_up}, Down: {vresult.n_down}{pair_info})")
+            print(
+                f"    Significant: {vresult.n_significant} "
+                f"(Up: {vresult.n_up}, Down: {vresult.n_down}{pair_info})"
+            )
             if is_paired and vresult.resolution_overrides_applied:
-                print(f"    Paired overrides applied: {len(vresult.resolution_overrides_applied)}")
+                print(
+                    f"    Paired overrides applied: {len(vresult.resolution_overrides_applied)}"
+                )
                 for record in vresult.resolution_overrides_applied:
                     paired_resolution_audit_rows.append(
                         {
@@ -947,7 +1097,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                         }
                     )
             if is_paired and vresult.resolution_warnings:
-                print(f"    Paired resolution warnings: {len(vresult.resolution_warnings)}")
+                print(
+                    f"    Paired resolution warnings: {len(vresult.resolution_warnings)}"
+                )
                 for warning in vresult.resolution_warnings:
                     print(f"      - {warning}")
                     paired_resolution_audit_rows.append(
@@ -961,20 +1113,24 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                             "candidates": "",
                         }
                     )
-            vresult.result_df = _annotate_feature_table(vresult.result_df, final_feature_metadata)
+            vresult.result_df = _annotate_feature_table(
+                vresult.result_df, final_feature_metadata
+            )
             vresult.result_df.to_csv(
                 os.path.join(output_dir, f"volcano_{g1}_vs_{g2}.csv"),
                 index=False,
             )
 
             # Collect volcano significant features for Excel export
-            vol_sig = _annotate_feature_table(vresult.significant.copy(), final_feature_metadata)
+            vol_sig = _annotate_feature_table(
+                vresult.significant.copy(), final_feature_metadata
+            )
             if not vol_sig.empty:
                 vol_sig = vol_sig.sort_values("pvalue_adj").head(50)
                 _excel_sheets[f"Volcano_{g1}_vs_{g2}"] = vol_sig
             fig = plt.figure(figsize=(10, 8))
             plot_volcano(vresult, fig=fig)
-            _save_figure(fig, report_dirs["feature"] / f"volcano_{g1}_vs_{g2}.png")
+            _save_figure(fig, report_dirs["feature"] / f"volcano_{g1}_vs_{g2}.png", draft_mode=draft_mode)
             print(f"    Saved {REPORT_SUBDIRS['feature']}\\volcano_{g1}_vs_{g2}.png")
         except Exception as e:
             print(f"    Error: {e}")
@@ -1012,14 +1168,20 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
             fig = plt.figure(figsize=(8, 6))
             plot_roc_curves(roc_result, fig=fig)
-            _save_figure(fig, report_dirs["validation"] / f"roc_{g1}_vs_{g2}.png")
+            _save_figure(fig, report_dirs["validation"] / f"roc_{g1}_vs_{g2}.png", draft_mode=draft_mode)
 
             fig = plt.figure(figsize=(8, 6))
             plot_auc_ranking(roc_result, fig=fig)
-            _save_figure(fig, report_dirs["validation"] / f"auc_ranking_{g1}_vs_{g2}.png")
+            _save_figure(
+                fig,
+                report_dirs["validation"] / f"auc_ranking_{g1}_vs_{g2}.png",
+                draft_mode=draft_mode,
+            )
 
             print(f"    Saved {REPORT_SUBDIRS['validation']}\\roc_{g1}_vs_{g2}.png")
-            print(f"    Saved {REPORT_SUBDIRS['validation']}\\auc_ranking_{g1}_vs_{g2}.png")
+            print(
+                f"    Saved {REPORT_SUBDIRS['validation']}\\auc_ranking_{g1}_vs_{g2}.png"
+            )
         except Exception as e:
             print(f"    Error: {e}")
 
@@ -1040,11 +1202,11 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
         fig = plt.figure(figsize=(8, 6))
         plot_outlier_score(outlier_result, labels=final_labels, fig=fig)
-        _save_figure(fig, report_dirs["supplementary"] / "outlier_t2.png")
+        _save_figure(fig, report_dirs["supplementary"] / "outlier_t2.png", draft_mode=draft_mode)
 
         fig = plt.figure(figsize=(8, 6))
         plot_dmodx(outlier_result, labels=final_labels, fig=fig)
-        _save_figure(fig, report_dirs["supplementary"] / "outlier_dmodx.png")
+        _save_figure(fig, report_dirs["supplementary"] / "outlier_dmodx.png", draft_mode=draft_mode)
         print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_t2.png")
         print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_dmodx.png")
     except Exception as e:
@@ -1081,14 +1243,26 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
             fig = plt.figure(figsize=(8, 6))
             plot_rf_importance(rf_result, top_n=rf_top_n, fig=fig)
-            _save_figure(fig, report_dirs["supplementary"] / f"rf_importance_{g1}_vs_{g2}.png")
+            _save_figure(
+                fig,
+                report_dirs["supplementary"] / f"rf_importance_{g1}_vs_{g2}.png",
+                draft_mode=draft_mode,
+            )
 
             fig = plt.figure(figsize=(6, 5))
             plot_confusion_matrix(rf_result, fig=fig)
-            _save_figure(fig, report_dirs["supplementary"] / f"rf_confusion_matrix_{g1}_vs_{g2}.png")
+            _save_figure(
+                fig,
+                report_dirs["supplementary"] / f"rf_confusion_matrix_{g1}_vs_{g2}.png",
+                draft_mode=draft_mode,
+            )
 
-            print(f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_importance_{g1}_vs_{g2}.png")
-            print(f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_confusion_matrix_{g1}_vs_{g2}.png")
+            print(
+                f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_importance_{g1}_vs_{g2}.png"
+            )
+            print(
+                f"    Saved {REPORT_SUBDIRS['supplementary']}\\rf_confusion_matrix_{g1}_vs_{g2}.png"
+            )
         except Exception as e:
             print(f"    Error: {e}")
 
@@ -1103,7 +1277,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     export_top_n = cfg.get("output", {}).get("export_top_n")
     try:
         _export_significant_features_excel(
-            _excel_sheets, output_dir, top_n=export_top_n,
+            _excel_sheets,
+            output_dir,
+            top_n=export_top_n,
         )
     except Exception as e:
         print(f"  Excel export error: {e}")
@@ -1123,6 +1299,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
 # ── CLI entry point ───────────────────────────────────────
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Run MetaboAnalyst pipeline from a YAML config file.",
@@ -1133,12 +1310,14 @@ def main():
         help="Path to YAML configuration file (e.g., configs/step4_dnp_specnorm.yaml)",
     )
     parser.add_argument(
-        "--input", "-i",
+        "--input",
+        "-i",
         help="Override the input file path from config (e.g., path/to/data.xlsx)",
         default=None,
     )
     parser.add_argument(
-        "--suffix", "-s",
+        "--suffix",
+        "-s",
         help="Append a suffix to the output folder name (e.g., _control, _strict)",
         default=None,
     )

--- a/tests/test_publication_batch_report_smoke.py
+++ b/tests/test_publication_batch_report_smoke.py
@@ -22,7 +22,9 @@ pytestmark = pytest.mark.integration
 
 
 class _DummyPipeline:
-    def __init__(self, data: pd.DataFrame, labels: pd.Series, feature_metadata: pd.DataFrame) -> None:
+    def __init__(
+        self, data: pd.DataFrame, labels: pd.Series, feature_metadata: pd.DataFrame
+    ) -> None:
         self._data = data
         self._labels = labels
         self._feature_metadata = feature_metadata
@@ -213,7 +215,9 @@ def _stub_plot(label: str):
     return _plot
 
 
-def _install_smoke_stubs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
+def _install_smoke_stubs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
     sample_names = [
         "Exposure_A",
         "Exposure_B",
@@ -245,23 +249,45 @@ def _install_smoke_stubs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tup
     )
 
     monkeypatch.setattr(run_mod, "_PROJECT_ROOT", str(tmp_path))
-    monkeypatch.setattr(run_mod, "load_data", lambda cfg: (data.copy(), labels.copy(), feature_metadata.copy()))
+    monkeypatch.setattr(
+        run_mod,
+        "load_data",
+        lambda cfg: (data.copy(), labels.copy(), feature_metadata.copy()),
+    )
     monkeypatch.setattr(run_mod, "MetaboAnalystPipeline", _DummyPipeline)
     monkeypatch.setattr(run_mod, "run_pca", lambda *args, **kwargs: _DummyPCAResult())
-    monkeypatch.setattr(run_mod, "run_anova", lambda *args, **kwargs: _DummyANOVAResult(features))
+    monkeypatch.setattr(
+        run_mod, "run_anova", lambda *args, **kwargs: _DummyANOVAResult(features)
+    )
     monkeypatch.setattr(
         run_mod,
         "volcano_analysis",
-        lambda *args, **kwargs: _DummyVolcanoResult(features, kwargs["group1"], kwargs["group2"]),
+        lambda *args, **kwargs: _DummyVolcanoResult(
+            features, kwargs["group1"], kwargs["group2"]
+        ),
     )
-    monkeypatch.setattr(run_mod, "run_roc_analysis", lambda *args, **kwargs: _make_roc_result())
-    monkeypatch.setattr(run_mod, "run_random_forest", lambda *args, **kwargs: _make_rf_result(features))
-    monkeypatch.setattr(run_mod, "run_outlier_detection", lambda *args, **kwargs: _DummyOutlierResult(sample_names))
+    monkeypatch.setattr(
+        run_mod, "run_roc_analysis", lambda *args, **kwargs: _make_roc_result()
+    )
+    monkeypatch.setattr(
+        run_mod, "run_random_forest", lambda *args, **kwargs: _make_rf_result(features)
+    )
+    monkeypatch.setattr(
+        run_mod,
+        "run_outlier_detection",
+        lambda *args, **kwargs: _DummyOutlierResult(sample_names),
+    )
 
-    monkeypatch.setattr(run_mod, "plot_norm_comparison", _stub_plot("Normalization Comparison"))
+    monkeypatch.setattr(
+        run_mod, "plot_norm_comparison", _stub_plot("Normalization Comparison")
+    )
     monkeypatch.setattr(run_mod, "plot_pca_score", _stub_plot("PCA Score Plot"))
-    monkeypatch.setattr(run_mod, "plot_anova_importance", _stub_plot("ANOVA Importance Plot"))
-    monkeypatch.setattr(run_mod, "plot_feature_boxplot", _stub_plot("ANOVA Feature Boxplot"))
+    monkeypatch.setattr(
+        run_mod, "plot_anova_importance", _stub_plot("ANOVA Importance Plot")
+    )
+    monkeypatch.setattr(
+        run_mod, "plot_feature_boxplot", _stub_plot("ANOVA Feature Boxplot")
+    )
     monkeypatch.setattr(run_mod, "plot_heatmap", _stub_plot("Heatmap"))
     monkeypatch.setattr(run_mod, "plot_oplsda_splot", _stub_plot("OPLS-DA S-Plot"))
     monkeypatch.setattr(run_mod, "plot_outlier_score", _stub_plot("Outlier T2"))
@@ -271,11 +297,25 @@ def _install_smoke_stubs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tup
     monkeypatch.setattr(run_mod, "plot_rf_importance", _stub_plot("RF Importance"))
     monkeypatch.setattr(run_mod, "plot_confusion_matrix", _stub_plot("RF Confusion"))
 
-    monkeypatch.setattr(ms_plsda_mod, "run_plsda", lambda *args, **kwargs: _DummyPLSDAResult(features, ["Exposure", "Normal", "Control"]))
-    monkeypatch.setattr(ms_plsda_plot_mod, "plot_plsda_score", _stub_plot("PLS-DA Score Plot"))
+    monkeypatch.setattr(
+        ms_plsda_mod,
+        "run_plsda",
+        lambda *args, **kwargs: _DummyPLSDAResult(
+            features, ["Exposure", "Normal", "Control"]
+        ),
+    )
+    monkeypatch.setattr(
+        ms_plsda_plot_mod, "plot_plsda_score", _stub_plot("PLS-DA Score Plot")
+    )
     monkeypatch.setattr(ms_vip_plot_mod, "plot_vip", _stub_plot("PLS-DA VIP Plot"))
-    monkeypatch.setattr(ms_oplsda_mod, "run_oplsda", lambda *args, **kwargs: _DummyOPLSDAResult(features, ["Exposure", "Normal"]))
-    monkeypatch.setattr(ms_oplsda_plot_mod, "plot_oplsda_score", _stub_plot("OPLS-DA Score Plot"))
+    monkeypatch.setattr(
+        ms_oplsda_mod,
+        "run_oplsda",
+        lambda *args, **kwargs: _DummyOPLSDAResult(features, ["Exposure", "Normal"]),
+    )
+    monkeypatch.setattr(
+        ms_oplsda_plot_mod, "plot_oplsda_score", _stub_plot("OPLS-DA Score Plot")
+    )
     monkeypatch.setattr(volcano_plot_mod, "plot_volcano", _stub_plot("Volcano Plot"))
 
     return data, labels, feature_metadata
@@ -315,7 +355,12 @@ def _build_publication_config(tmp_path: Path) -> dict:
         "analysis": {
             "pca": {"n_components": 3},
             "plsda": {"n_components": 2, "top_vip": 15},
-            "anova": {"p_thresh": 0.05, "nonpar": False, "use_fdr": True, "posthoc": True},
+            "anova": {
+                "p_thresh": 0.05,
+                "nonpar": False,
+                "use_fdr": True,
+                "posthoc": True,
+            },
             "volcano": {
                 "fc_thresh": 2.0,
                 "log2_fc_thresh": 1.0,
@@ -323,7 +368,13 @@ def _build_publication_config(tmp_path: Path) -> dict:
                 "use_fdr": True,
                 "parametric_test_default": "welch",
             },
-            "heatmap": {"max_features": 50, "top_by": "var", "method": "ward", "metric": "euclidean", "scale": "row"},
+            "heatmap": {
+                "max_features": 50,
+                "top_by": "var",
+                "method": "ward",
+                "metric": "euclidean",
+                "scale": "row",
+            },
             "roc": {"top_n": 10, "multi_feature": True},
             "outlier": {"n_components": 2, "alpha": 0.05},
             "random_forest": {"n_trees": 500, "cv_folds": 5, "top_n": 25},
@@ -335,7 +386,9 @@ def _build_publication_config(tmp_path: Path) -> dict:
     }
 
 
-def test_publication_report_smoke_layout_and_pruning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_publication_report_smoke_layout_and_pruning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     _install_smoke_stubs(monkeypatch, tmp_path)
     cfg = _build_publication_config(tmp_path)
 
@@ -350,14 +403,15 @@ def test_publication_report_smoke_layout_and_pruning(monkeypatch: pytest.MonkeyP
         output_dir / "05_Supplementary",
     ]
     expected_files = [
-        output_dir / "config_used.yaml",
-        output_dir / "processed_data.csv",
-        output_dir / "sample_labels.csv",
-        output_dir / "feature_metadata.csv",
-        output_dir / "anova_results.csv",
-        output_dir / "roc_Exposure_vs_Normal.csv",
-        output_dir / "rf_importance_Exposure_vs_Normal.csv",
-        output_dir / "outlier_results.csv",
+        output_dir / "01_QC_and_Preprocessing" / "config_used.yaml",
+        output_dir / "01_QC_and_Preprocessing" / "processed_data.csv",
+        output_dir / "01_QC_and_Preprocessing" / "sample_labels.csv",
+        output_dir / "01_QC_and_Preprocessing" / "feature_metadata.csv",
+        output_dir / "01_QC_and_Preprocessing" / "pipeline_log.txt",
+        output_dir / "03_Feature_Selection" / "anova_results.csv",
+        output_dir / "04_Biomarker_Validation" / "roc_Exposure_vs_Normal.csv",
+        output_dir / "05_Supplementary" / "rf_importance_Exposure_vs_Normal.csv",
+        output_dir / "05_Supplementary" / "outlier_results.csv",
         output_dir / "01_QC_and_Preprocessing" / "normalization_comparison.png",
         output_dir / "01_QC_and_Preprocessing" / "pca_score_plot.png",
         output_dir / "02_Global_Profiling" / "heatmap_top50.png",
@@ -393,4 +447,6 @@ def test_publication_report_smoke_layout_and_pruning(monkeypatch: pytest.MonkeyP
         assert file_path.is_file(), f"missing report file: {file_path}"
 
     for file_path in legacy_files:
-        assert not file_path.exists(), f"legacy output should not be emitted: {file_path}"
+        assert not file_path.exists(), (
+            f"legacy output should not be emitted: {file_path}"
+        )

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -55,3 +55,31 @@ class TestSaveFigureDualOutput:
         _save_figure(fig, out, draft_mode=True)
         assert out.exists()
         assert not out.with_suffix(".pdf").exists()
+
+
+class TestOplsdaEllipseNoFill:
+    def test_ellipse_has_no_facecolor(self):
+        from visualization.oplsda_plot import _confidence_ellipse
+
+        fig, ax = plt.subplots()
+        x = np.random.randn(20)
+        y = np.random.randn(20)
+        _confidence_ellipse(ax, x, y, color="#E64B35", fill_color="#E64B35")
+        patches = [p for p in ax.patches if hasattr(p, "get_facecolor")]
+        assert len(patches) == 1
+        fc = patches[0].get_facecolor()
+        assert fc[3] == 0.0 or patches[0].get_fill() is False
+        plt.close(fig)
+
+    def test_ellipse_has_dashed_linestyle(self):
+        from visualization.oplsda_plot import _confidence_ellipse
+
+        fig, ax = plt.subplots()
+        x = np.random.randn(20)
+        y = np.random.randn(20)
+        _confidence_ellipse(ax, x, y, color="#E64B35", fill_color="#E64B35")
+        patches = [p for p in ax.patches if hasattr(p, "get_linestyle")]
+        assert len(patches) == 1
+        ls = patches[0].get_linestyle()
+        assert ls != (0, None)  # not solid
+        plt.close(fig)

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -105,3 +105,31 @@ class TestAnovaBoxplotJitter:
             "Expected jittered scatter overlays for each group"
         )
         plt.close(fig)
+
+
+class TestOutlierPlotLayout:
+    def test_outlier_score_figsize_2_to_1(self):
+        from unittest.mock import MagicMock
+
+        from analysis.outlier import OutlierResult
+        from visualization.outlier_plot import plot_outlier_score
+
+        n = 10
+        rng = np.random.default_rng(42)
+        result = OutlierResult(
+            scores=rng.standard_normal((n, 2)),
+            t2_values=rng.random(n) * 10,
+            t2_threshold=6.0,
+            outlier_mask_t2=np.array([False] * 9 + [True]),
+            dmodx=rng.random(n),
+            dmodx_threshold=2.0,
+            outlier_mask_dmodx=np.array([False] * 9 + [True]),
+            explained_variance=np.array([0.4, 0.3]),
+            sample_names=[f"S{i}" for i in range(n)],
+            pca_model=MagicMock(),
+        )
+        fig = plot_outlier_score(result)
+        w, h = fig.get_size_inches()
+        ratio = w / h
+        assert 2.0 <= ratio <= 2.5, f"Expected ~2:1 ratio, got {ratio:.2f}"
+        plt.close(fig)

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -1,0 +1,57 @@
+"""Smoke tests for publication report v2 improvements."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+
+class TestPublicationExportStyle:
+    def test_sets_arial_font(self):
+        from visualization.theme import apply_publication_export_style
+
+        apply_publication_export_style("light")
+        assert "Arial" in plt.rcParams["font.family"]
+
+    def test_sets_300_dpi(self):
+        from visualization.theme import apply_publication_export_style
+
+        apply_publication_export_style("light")
+        assert plt.rcParams["savefig.dpi"] == 300
+        assert plt.rcParams["figure.dpi"] == 300
+
+    def test_inherits_base_style(self):
+        from visualization.theme import apply_publication_export_style
+
+        apply_publication_export_style("light")
+        assert plt.rcParams["axes.spines.top"] is False
+        assert plt.rcParams["axes.spines.right"] is False
+        assert plt.rcParams["legend.frameon"] is False
+
+
+class TestSaveFigureDualOutput:
+    def test_publication_mode_creates_png_and_pdf(self, tmp_path):
+        from scripts.run_from_config import _save_figure
+
+        fig = plt.figure()
+        fig.add_subplot(111).plot([1, 2], [3, 4])
+        out = tmp_path / "test.png"
+        _save_figure(fig, out, draft_mode=False)
+        assert out.exists()
+        assert out.with_suffix(".pdf").exists()
+
+    def test_draft_mode_creates_png_only(self, tmp_path):
+        from scripts.run_from_config import _save_figure
+
+        fig = plt.figure()
+        fig.add_subplot(111).plot([1, 2], [3, 4])
+        out = tmp_path / "test.png"
+        _save_figure(fig, out, draft_mode=True)
+        assert out.exists()
+        assert not out.with_suffix(".pdf").exists()

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -161,3 +161,14 @@ class TestConfusionMatrixVmax:
         assert "vmax" in sig.parameters, (
             "plot_confusion_matrix should accept vmax parameter"
         )
+
+
+class TestHeatmapLabelThreshold:
+    """Heatmap should hide x-labels when features > 50."""
+
+    def test_xticklabels_hidden_when_many_features(self):
+        import visualization.heatmap as hm
+
+        source = open(hm.__file__).read()
+        assert "xticklabels=False" in source
+        assert "50" in source

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -149,3 +149,15 @@ class TestLegendPositions:
 
         source = open(dp.__file__).read()
         assert 'loc="best"' not in source, "density_plot still uses loc='best'"
+
+
+class TestConfusionMatrixVmax:
+    def test_accepts_vmax_parameter(self):
+        import inspect
+
+        from visualization.rf_plot import plot_confusion_matrix
+
+        sig = inspect.signature(plot_confusion_matrix)
+        assert "vmax" in sig.parameters, (
+            "plot_confusion_matrix should accept vmax parameter"
+        )

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -1,15 +1,11 @@
 """Smoke tests for publication report v2 improvements."""
 
-import os
-from pathlib import Path
-from unittest.mock import patch
 
 import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
-import pytest
 
 
 class TestPublicationExportStyle:

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -133,3 +133,19 @@ class TestOutlierPlotLayout:
         ratio = w / h
         assert 2.0 <= ratio <= 2.5, f"Expected ~2:1 ratio, got {ratio:.2f}"
         plt.close(fig)
+
+
+class TestLegendPositions:
+    """Verify loc='best' is never used in publication plots."""
+
+    def test_volcano_legend_not_best(self):
+        import visualization.volcano_plot as vp
+
+        source = open(vp.__file__).read()
+        assert 'loc="best"' not in source, "volcano_plot still uses loc='best'"
+
+    def test_density_legend_not_best(self):
+        import visualization.density_plot as dp
+
+        source = open(dp.__file__).read()
+        assert 'loc="best"' not in source, "density_plot still uses loc='best'"

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -83,3 +83,25 @@ class TestOplsdaEllipseNoFill:
         ls = patches[0].get_linestyle()
         assert ls != (0, None)  # not solid
         plt.close(fig)
+
+
+class TestAnovaBoxplotJitter:
+    def test_scatter_points_present(self):
+        from visualization.anova_plot import _draw_r_style_boxplot
+        from visualization.theme import COLORS
+
+        fig, ax = plt.subplots()
+        config = COLORS["light"]
+        data = [
+            np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+            np.array([2.0, 3.0, 4.0, 5.0, 6.0]),
+        ]
+        _draw_r_style_boxplot(ax, data, ["A", "B"], ["#E64B35", "#4DBBD5"], config)
+
+        scatter_collections = [
+            c for c in ax.collections if type(c).__name__ == "PathCollection"
+        ]
+        assert len(scatter_collections) >= 2, (
+            "Expected jittered scatter overlays for each group"
+        )
+        plt.close(fig)

--- a/visualization/anova_plot.py
+++ b/visualization/anova_plot.py
@@ -263,13 +263,14 @@ def plot_feature_boxplot(
     stat_text = _build_stat_annotation(plot_data, annotation_method=annotation_method)
     fig.tight_layout()
     if stat_text:
-        fig.text(
-            0.02,
+        ax.text(
+            0.98,
             0.98,
             stat_text,
             va="top",
-            ha="left",
+            ha="right",
             fontsize=9,
+            transform=ax.transAxes,
             bbox={
                 "boxstyle": "round,pad=0.3",
                 "facecolor": config["background"],

--- a/visualization/anova_plot.py
+++ b/visualization/anova_plot.py
@@ -261,16 +261,17 @@ def plot_feature_boxplot(
     ax.tick_params(axis="x", labelsize=8)
 
     stat_text = _build_stat_annotation(plot_data, annotation_method=annotation_method)
-    fig.tight_layout()
+    fig.tight_layout(rect=[0, 0, 1, 0.90])
     if stat_text:
         ax.text(
             0.98,
-            0.98,
+            1.02,
             stat_text,
-            va="top",
+            va="bottom",
             ha="right",
             fontsize=9,
             transform=ax.transAxes,
+            clip_on=False,
             bbox={
                 "boxstyle": "round,pad=0.3",
                 "facecolor": config["background"],

--- a/visualization/anova_plot.py
+++ b/visualization/anova_plot.py
@@ -49,7 +49,9 @@ def plot_anova_importance(
     df = df.iloc[::-1]
 
     palette = get_group_colors(theme, 2)
-    bar_colors = [palette[0] if is_sig else config["grid"] for is_sig in df["significant"]]
+    bar_colors = [
+        palette[0] if is_sig else config["grid"] for is_sig in df["significant"]
+    ]
 
     ax.barh(range(len(df)), df["neg_log10p"].values, color=bar_colors, height=0.7)
     ax.set_yticks(range(len(df)))
@@ -65,7 +67,11 @@ def plot_anova_importance(
     ax.set_xlabel("-log10(adj. p-value)")
     ax.tick_params(axis="x", labelsize=9)
     method_key = str(getattr(anova_result, "method_key", "anova")).lower()
-    title = "Kruskal-Wallis: Important Features" if method_key == "kruskal" else "ANOVA: Important Features"
+    title = (
+        "Kruskal-Wallis: Important Features"
+        if method_key == "kruskal"
+        else "ANOVA: Important Features"
+    )
     ax.set_title(title)
     ax.legend(loc="lower right", fontsize=8)
     fig.tight_layout(pad=1.0)
@@ -83,9 +89,14 @@ def _build_stat_annotation(
             grouped_values.append(values)
 
     if annotation_method == "mannwhitney":
-        if len(grouped_values) != 2 or min(len(grouped_values[0]), len(grouped_values[1])) < 2:
+        if (
+            len(grouped_values) != 2
+            or min(len(grouped_values[0]), len(grouped_values[1])) < 2
+        ):
             return ""
-        u_stat, p_val = mannwhitneyu(grouped_values[0], grouped_values[1], alternative="two-sided")
+        u_stat, p_val = mannwhitneyu(
+            grouped_values[0], grouped_values[1], alternative="two-sided"
+        )
         return f"P = {p_val:.2e}\nMann-Whitney U = {u_stat:.4f}"
 
     if annotation_method == "kruskal":
@@ -139,7 +150,9 @@ def _draw_r_style_boxplot(
             patch_artist=True,
             showmeans=False,
             showfliers=True,
-            boxprops=dict(facecolor=color, edgecolor=config["axes_line"], linewidth=1.0),
+            boxprops=dict(
+                facecolor=color, edgecolor=config["axes_line"], linewidth=1.0
+            ),
             medianprops=dict(color=config["text"], linewidth=1.5),
             whiskerprops=dict(color=config["axes_line"], linewidth=1.0),
             capprops=dict(color=config["axes_line"], linewidth=1.0),
@@ -160,6 +173,18 @@ def _draw_r_style_boxplot(
             markeredgecolor="#B8860B",
             markeredgewidth=0.7,
             zorder=4,
+        )
+        # Overlay jittered raw data points
+        jitter = np.random.default_rng(42).uniform(-0.15, 0.15, size=len(clean))
+        ax.scatter(
+            positions[idx] + jitter,
+            clean,
+            c=color,
+            s=18,
+            alpha=0.5,
+            edgecolors="white",
+            linewidths=0.3,
+            zorder=3,
         )
 
     ax.set_xticks(positions)
@@ -220,7 +245,9 @@ def plot_feature_boxplot(
 
     groups = sorted(plot_data["Group"].unique())
     data_by_group = [
-        pd.to_numeric(plot_data.loc[plot_data["Group"] == group, "Value"], errors="coerce")
+        pd.to_numeric(
+            plot_data.loc[plot_data["Group"] == group, "Value"], errors="coerce"
+        )
         .dropna()
         .to_numpy()
         for group in groups

--- a/visualization/density_plot.py
+++ b/visualization/density_plot.py
@@ -62,7 +62,11 @@ def plot_density(
 
     plotted_groups: set[str] = set()
     for row_idx in range(len(df)):
-        values = pd.to_numeric(df.iloc[row_idx], errors="coerce").dropna().to_numpy(dtype=float)
+        values = (
+            pd.to_numeric(df.iloc[row_idx], errors="coerce")
+            .dropna()
+            .to_numpy(dtype=float)
+        )
         if len(values) < 2:
             continue
 
@@ -80,6 +84,6 @@ def plot_density(
     ax.set_ylabel("Density")
     ax.set_title(title)
     if plotted_groups:
-        ax.legend(loc="best", fontsize=9)
+        ax.legend(loc="upper right", fontsize=9)
     fig.tight_layout()
     return fig

--- a/visualization/heatmap.py
+++ b/visualization/heatmap.py
@@ -84,12 +84,17 @@ def plot_heatmap(
             linewidths=0,
             xticklabels=False if plot_df.shape[1] > 50 else True,
             yticklabels=False if plot_df.shape[0] > 50 else True,
+            cbar_pos=(0.88, 0.06, 0.03, 0.16),
         )
-        cluster_grid.fig.suptitle("Heatmap with Hierarchical Clustering", y=1.01, fontsize=12)
+        cluster_grid.fig.suptitle(
+            "Heatmap with Hierarchical Clustering", y=1.01, fontsize=12
+        )
 
         from matplotlib.patches import Patch
 
-        legend_elements = [Patch(facecolor=palette[group], label=str(group)) for group in groups]
+        legend_elements = [
+            Patch(facecolor=palette[group], label=str(group)) for group in groups
+        ]
         cluster_grid.ax_heatmap.legend(
             handles=legend_elements,
             loc="upper left",

--- a/visualization/heatmap.py
+++ b/visualization/heatmap.py
@@ -84,10 +84,20 @@ def plot_heatmap(
             linewidths=0,
             xticklabels=False if plot_df.shape[1] > 50 else True,
             yticklabels=False if plot_df.shape[0] > 50 else True,
-            cbar_pos=(0.88, 0.06, 0.03, 0.16),
+            cbar_pos=(0.02, 0.82, 0.03, 0.14),
         )
         cluster_grid.fig.suptitle(
             "Heatmap with Hierarchical Clustering", y=1.01, fontsize=12
+        )
+
+        # Move colorbar to right side, below the Group legend, avoiding x-axis labels.
+        # cbar_pos is in figure coordinates; repositioning after layout avoids
+        # guessing where rotated x-tick labels end up.
+        cluster_grid.fig.canvas.draw()
+        hm_pos = cluster_grid.ax_heatmap.get_position()
+        cb_left = hm_pos.x1 + 0.01
+        cluster_grid.cax.set_position(
+            [cb_left, hm_pos.y0 + 0.02, 0.022, hm_pos.height * 0.35]
         )
 
         from matplotlib.patches import Patch

--- a/visualization/norm_preview.py
+++ b/visualization/norm_preview.py
@@ -54,7 +54,9 @@ def plot_norm_comparison(
 
     groups = _unique_preserve_order(labels_arr)
     if not groups:
-        _draw_empty_norm_figure(fig, "Normalization Comparison", "No samples available.")
+        _draw_empty_norm_figure(
+            fig, "Normalization Comparison", "No samples available."
+        )
         return fig
 
     palette = get_group_colors(theme, len(groups))
@@ -72,7 +74,9 @@ def plot_norm_comparison(
     )
 
     ax1 = fig.add_subplot(gs[0, 0])
-    _draw_group_box(ax1, before_df, labels_arr, groups, color_map, "Before normalization")
+    _draw_group_box(
+        ax1, before_df, labels_arr, groups, color_map, "Before normalization"
+    )
     ax1.set_title("Before normalization", fontsize=10.5, fontweight="bold", pad=8)
 
     ax2 = fig.add_subplot(gs[0, 1])
@@ -80,35 +84,36 @@ def plot_norm_comparison(
     ax2.set_title("After normalization", fontsize=10.5, fontweight="bold", pad=8)
 
     ax3 = fig.add_subplot(gs[1, 0])
-    _draw_density(ax3, before_df, labels_arr, groups, color_map, density_x, "Before density")
+    _draw_density(
+        ax3, before_df, labels_arr, groups, color_map, density_x, "Before density"
+    )
     ax3.set_title("Before density", fontsize=10.5, fontweight="bold", pad=8)
 
     ax4 = fig.add_subplot(gs[1, 1])
-    _draw_density(ax4, after_df, labels_arr, groups, color_map, density_x, "After density")
+    _draw_density(
+        ax4, after_df, labels_arr, groups, color_map, density_x, "After density"
+    )
     ax4.set_title("After density", fontsize=10.5, fontweight="bold", pad=8)
 
     handles = [
-        Patch(facecolor=color_map[group], edgecolor=color_map[group], label=str(group), alpha=0.7)
+        Patch(
+            facecolor=color_map[group],
+            edgecolor=color_map[group],
+            label=str(group),
+            alpha=0.7,
+        )
         for group in groups
     ]
     fig.suptitle("Normalization Comparison", fontsize=14, fontweight="bold", y=0.98)
     fig.legend(
         handles=handles,
         loc="lower center",
-        bbox_to_anchor=(0.5, 0.02),
+        bbox_to_anchor=(0.5, 0.0),
         ncol=min(len(handles), 4),
         frameon=False,
         fontsize=8.5,
     )
-    fig.text(
-        0.5,
-        0.06,
-        "Top row: grouped boxplots. Bottom row: density curves. Shared x-limits are used for direct before/after comparison.",
-        ha="center",
-        va="center",
-        fontsize=8,
-    )
-    fig.tight_layout(rect=[0.02, 0.10, 0.98, 0.95])
+    fig.tight_layout(rect=[0.02, 0.06, 0.98, 0.95])
     return fig
 
 

--- a/visualization/oplsda_plot.py
+++ b/visualization/oplsda_plot.py
@@ -171,7 +171,7 @@ def plot_oplsda_score(
         )
     else:
         ax.set_ylabel(f"Orthogonal T score [1] ({var_o:.1f} %)", fontsize=10.5)
-    ax.set_title("Scores Plot", fontsize=12, fontweight="bold", pad=10)
+    ax.set_title("OPLS-DA Scores Plot", fontsize=12, fontweight="bold", pad=10)
     ax.legend(
         handles=legend_handles,
         bbox_to_anchor=(1.05, 1),

--- a/visualization/oplsda_plot.py
+++ b/visualization/oplsda_plot.py
@@ -11,6 +11,13 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Ellipse
 from scipy.stats import chi2
 
+try:
+    from adjustText import adjust_text
+
+    _HAS_ADJUSTTEXT = True
+except ImportError:
+    _HAS_ADJUSTTEXT = False
+
 from visualization.interactive_score_plot import build_interactive_score_plot
 from visualization.score_labeling import add_score_labels, finalize_score_labels
 from visualization.theme import apply_publication_style, get_group_colors
@@ -44,10 +51,10 @@ def _confidence_ellipse(ax, x, y, color, fill_color, confidence: float = 0.95) -
             width=width,
             height=height,
             angle=angle,
-            facecolor=fill_color,
+            facecolor="none",
             edgecolor=color,
-            alpha=0.25,
-            linewidth=0.8,
+            linestyle="--",
+            linewidth=1.2,
             zorder=1,
         )
     )
@@ -303,18 +310,16 @@ def plot_oplsda_splot(
     )
 
     top_idx = _select_balanced_annotation_indices(loadings, importance, top_n)
+    texts = []
     for rank, idx in enumerate(top_idx, start=1):
-        offset_x = 6 if loadings[idx] >= 0 else -6
-        align = "left" if offset_x > 0 else "right"
-        ax.annotate(
+        txt = ax.text(
+            loadings[idx],
+            importance[idx],
             features[idx][:24],
-            (loadings[idx], importance[idx]),
             fontsize=7.2,
             color=neutral_color,
             alpha=0.95,
-            xytext=(offset_x, 5 if rank % 2 else -6),
-            textcoords="offset points",
-            ha=align,
+            ha="left" if loadings[idx] >= 0 else "right",
             va="bottom" if rank % 2 else "top",
             bbox={
                 "boxstyle": "round,pad=0.16",
@@ -323,6 +328,14 @@ def plot_oplsda_splot(
                 "linewidth": 0.6,
                 "alpha": 0.88,
             },
+        )
+        texts.append(txt)
+
+    if texts and _HAS_ADJUSTTEXT:
+        adjust_text(
+            texts,
+            ax=ax,
+            arrowprops=dict(arrowstyle="-", color=neutral_color, lw=0.5),
         )
 
     ax.axvline(0, color="grey", linewidth=0.8, linestyle="-", alpha=0.6)
@@ -342,8 +355,18 @@ def plot_oplsda_splot(
     )
     ax.legend(
         handles=[
-            Patch(facecolor=positive_color, edgecolor=positive_color, label="Positive loading", alpha=0.55),
-            Patch(facecolor=negative_color, edgecolor=negative_color, label="Negative loading", alpha=0.55),
+            Patch(
+                facecolor=positive_color,
+                edgecolor=positive_color,
+                label="Positive loading",
+                alpha=0.55,
+            ),
+            Patch(
+                facecolor=negative_color,
+                edgecolor=negative_color,
+                label="Negative loading",
+                alpha=0.55,
+            ),
         ],
         loc="upper right",
         frameon=False,

--- a/visualization/outlier_plot.py
+++ b/visualization/outlier_plot.py
@@ -11,6 +11,13 @@ from scipy.stats import chi2
 
 from visualization.theme import COLORS, apply_publication_style, get_group_colors
 
+try:
+    from adjustText import adjust_text
+
+    _HAS_ADJUSTTEXT = True
+except ImportError:
+    _HAS_ADJUSTTEXT = False
+
 
 def plot_outlier_score(
     outlier_result,
@@ -42,7 +49,7 @@ def plot_outlier_score(
     config = COLORS.get(theme, COLORS["light"])
 
     if fig is None:
-        fig = plt.figure(figsize=(10, 5))
+        fig = plt.figure(figsize=(16, 7))
     fig.clf()
 
     scores = outlier_result.scores
@@ -66,7 +73,8 @@ def plot_outlier_score(
     outlier_mask = outlier_mask[mask]
     sample_names = sample_names[mask]
 
-    ax1 = fig.add_subplot(121)
+    gs = fig.add_gridspec(1, 2, wspace=0.3)
+    ax1 = fig.add_subplot(gs[0, 0])
     if labels_arr is not None:
         filtered_labels = labels_arr[mask].astype(str)
         groups = sorted(set(filtered_labels))
@@ -122,7 +130,9 @@ def plot_outlier_score(
     else:
         palette = get_group_colors(theme, 2)
         normal = ~outlier_mask
-        ax1.scatter(x[normal], y[normal], c=palette[1], alpha=0.75, s=40, label="Normal")
+        ax1.scatter(
+            x[normal], y[normal], c=palette[1], alpha=0.75, s=40, label="Normal"
+        )
         ax1.scatter(
             x[outlier_mask],
             y[outlier_mask],
@@ -134,13 +144,22 @@ def plot_outlier_score(
         )
         ax1.legend(fontsize=8)
 
+    outlier_texts = []
     for idx in np.where(outlier_mask)[0]:
-        ax1.annotate(
+        txt = ax1.text(
+            x[idx],
+            y[idx],
             str(sample_names[idx]),
-            (x[idx], y[idx]),
             fontsize=7,
             color=config["text"],
             alpha=0.9,
+        )
+        outlier_texts.append(txt)
+    if outlier_texts and _HAS_ADJUSTTEXT:
+        adjust_text(
+            outlier_texts,
+            ax=ax1,
+            arrowprops=dict(arrowstyle="-", color=config["text"], lw=0.5),
         )
 
     if len(x) > 2 and scores.shape[1] > 1:
@@ -170,9 +189,11 @@ def plot_outlier_score(
     scope_text = f" - {group_filter}" if group_filter is not None else ""
     ax1.set_title(f"PCA Score Plot - Outlier Detection{scope_text}")
 
-    ax2 = fig.add_subplot(122)
+    ax2 = fig.add_subplot(gs[0, 1])
     palette = get_group_colors(theme, 2)
-    bar_colors = [palette[0] if is_outlier else palette[1] for is_outlier in outlier_mask]
+    bar_colors = [
+        palette[0] if is_outlier else palette[1] for is_outlier in outlier_mask
+    ]
     ax2.bar(range(len(t2_values)), t2_values, color=bar_colors, alpha=0.75)
     ax2.axhline(
         y=outlier_result.t2_threshold,
@@ -186,7 +207,8 @@ def plot_outlier_score(
     ax2.set_title("Hotelling's T2")
     ax2.legend(fontsize=8)
 
-    fig.tight_layout()
+    fig.align_ylabels([ax1, ax2])
+    fig.set_layout_engine("constrained")
     return fig
 
 
@@ -218,7 +240,7 @@ def plot_dmodx(
     palette = get_group_colors(theme, 2)
 
     if fig is None:
-        fig = plt.figure(figsize=(8, 5))
+        fig = plt.figure(figsize=(10, 5))
     fig.clf()
     ax = fig.add_subplot(111)
 
@@ -247,14 +269,23 @@ def plot_dmodx(
     ax.set_title(f"DModX (Distance to Model){scope_text}")
     ax.legend(fontsize=8)
 
+    outlier_texts = []
     for idx in np.where(outlier_mask)[0]:
-        ax.annotate(
+        txt = ax.text(
+            idx,
+            dmodx[idx],
             str(sample_names[idx]),
-            (idx, dmodx[idx]),
             fontsize=7,
             color=palette[0],
             ha="center",
             va="bottom",
+        )
+        outlier_texts.append(txt)
+    if outlier_texts and _HAS_ADJUSTTEXT:
+        adjust_text(
+            outlier_texts,
+            ax=ax,
+            arrowprops=dict(arrowstyle="-", color=palette[0], lw=0.5),
         )
 
     fig.tight_layout()

--- a/visualization/rf_plot.py
+++ b/visualization/rf_plot.py
@@ -50,7 +50,9 @@ def plot_rf_importance(
     apply_publication_style(theme)
     imp_df = rf_result.feature_importance.head(top_n).copy()
     if "Importance" not in imp_df.columns or "Feature" not in imp_df.columns:
-        raise ValueError("rf_result.feature_importance must contain 'Feature' and 'Importance' columns.")
+        raise ValueError(
+            "rf_result.feature_importance must contain 'Feature' and 'Importance' columns."
+        )
 
     if fig is None:
         fig = plt.figure(figsize=(8, max(4, max(len(imp_df), 1) * 0.35)))
@@ -58,13 +60,22 @@ def plot_rf_importance(
     ax = fig.add_subplot(111)
 
     importances = imp_df["Importance"].fillna(0.0).to_numpy(dtype=float)
-    feature_labels = [_safe_feature_label(name, idx) for idx, name in enumerate(imp_df["Feature"])]
+    feature_labels = [
+        _safe_feature_label(name, idx) for idx, name in enumerate(imp_df["Feature"])
+    ]
     palette = get_group_colors(theme, 3)
     max_importance = float(np.nanmax(importances)) if len(importances) else 0.0
     if not np.isfinite(max_importance) or max_importance <= 0:
         colors = [palette[1]] * len(importances)
     else:
-        colors = [palette[0] if value >= max_importance * 0.66 else palette[1] if value >= max_importance * 0.33 else palette[2] for value in importances]
+        colors = [
+            palette[0]
+            if value >= max_importance * 0.66
+            else palette[1]
+            if value >= max_importance * 0.33
+            else palette[2]
+            for value in importances
+        ]
 
     ax.barh(range(len(imp_df)), importances, color=colors)
     ax.set_yticks(range(len(imp_df)))
@@ -84,6 +95,7 @@ def plot_confusion_matrix(
     rf_result,
     theme: str = "light",
     fig: Figure | None = None,
+    vmax: int | None = None,
 ) -> Figure:
     """
     Plot the Random Forest confusion matrix.
@@ -96,6 +108,9 @@ def plot_confusion_matrix(
         Visualization theme name.
     fig : Figure or None, default=None
         Existing figure to reuse. When ``None``, a new figure is created.
+    vmax : int or None, default=None
+        Upper bound of the color scale. When provided, all confusion matrices
+        in a batch share the same scale for direct visual comparison.
 
     Returns
     -------
@@ -112,8 +127,7 @@ def plot_confusion_matrix(
     class_names = rf_result.class_names
     cmap = sns.light_palette(get_group_colors(theme, 1)[0], as_cmap=True)
 
-    sns.heatmap(
-        cm,
+    heatmap_kwargs: dict = dict(
         annot=True,
         fmt="d",
         cmap=cmap,
@@ -121,7 +135,12 @@ def plot_confusion_matrix(
         yticklabels=class_names,
         ax=ax,
         linewidths=0.5,
+        vmin=0,
     )
+    if vmax is not None:
+        heatmap_kwargs["vmax"] = vmax
+
+    sns.heatmap(cm, **heatmap_kwargs)
     ax.set_xlabel("Predicted")
     ax.set_ylabel("True")
     ax.set_title(f"Confusion Matrix (CV)\nAccuracy {rf_result.cv_accuracy:.1%}")

--- a/visualization/roc_plot.py
+++ b/visualization/roc_plot.py
@@ -144,13 +144,27 @@ def plot_auc_ranking(
     ax.set_title("AUC Ranking")
     ax.axvline(x=0.5, color=palette[2], linestyle="--", alpha=0.6)
     ax.axvline(x=0.7, color=palette[0], linestyle="--", alpha=0.6)
-    ax.text(
-        0.51, len(summary) - 0.5, "Random", color=palette[2], fontsize=7.5, va="bottom"
-    )
-    ax.text(
-        0.71, len(summary) - 0.5, "Good", color=palette[0], fontsize=7.5, va="bottom"
-    )
     ax.invert_yaxis()
+    # Use transAxes so y position is independent of feature count and invert_yaxis.
+    # y=0.05 sits just above the x-axis without touching it.
+    ax.text(
+        0.51,
+        0.05,
+        "Random",
+        color=palette[2],
+        fontsize=7.5,
+        va="bottom",
+        transform=ax.transAxes,
+    )
+    ax.text(
+        0.71,
+        0.05,
+        "Good",
+        color=palette[0],
+        fontsize=7.5,
+        va="bottom",
+        transform=ax.transAxes,
+    )
     ax.set_xlim([0, 1])
     fig.tight_layout()
     return fig

--- a/visualization/roc_plot.py
+++ b/visualization/roc_plot.py
@@ -165,7 +165,14 @@ def plot_auc_ranking(
             label="Good (AUC≥0.7)",
         ),
     ]
-    ax.legend(handles=legend_handles, loc="upper right", fontsize=8, framealpha=0.85)
+    ax.legend(
+        handles=legend_handles,
+        loc="lower right",
+        bbox_to_anchor=(1.0, 1.0),
+        fontsize=8,
+        framealpha=0.85,
+        borderaxespad=0.3,
+    )
     ax.set_xlim([0, 1])
     fig.tight_layout()
     return fig

--- a/visualization/roc_plot.py
+++ b/visualization/roc_plot.py
@@ -68,8 +68,14 @@ def plot_roc_curves(
         best_idx = int(np.argmax(roc.tpr - roc.fpr))
         ax.plot(roc.fpr[best_idx], roc.tpr[best_idx], "o", color=color, markersize=6)
 
-    if show_multi and roc_result.multi_fpr is not None and roc_result.multi_tpr is not None:
-        multi_auc = roc_result.multi_auc if roc_result.multi_auc is not None else float("nan")
+    if (
+        show_multi
+        and roc_result.multi_fpr is not None
+        and roc_result.multi_tpr is not None
+    ):
+        multi_auc = (
+            roc_result.multi_auc if roc_result.multi_auc is not None else float("nan")
+        )
         ax.plot(
             roc_result.multi_fpr,
             roc_result.multi_tpr,
@@ -136,9 +142,14 @@ def plot_auc_ranking(
     ax.set_yticklabels(summary["Feature"].astype(str).values, fontsize=8)
     ax.set_xlabel("AUC")
     ax.set_title("AUC Ranking")
-    ax.axvline(x=0.5, color=palette[2], linestyle="--", alpha=0.6, label="Random")
-    ax.axvline(x=0.7, color=palette[0], linestyle="--", alpha=0.6, label="Good")
-    ax.legend(fontsize=8)
+    ax.axvline(x=0.5, color=palette[2], linestyle="--", alpha=0.6)
+    ax.axvline(x=0.7, color=palette[0], linestyle="--", alpha=0.6)
+    ax.text(
+        0.51, len(summary) - 0.5, "Random", color=palette[2], fontsize=7.5, va="bottom"
+    )
+    ax.text(
+        0.71, len(summary) - 0.5, "Good", color=palette[0], fontsize=7.5, va="bottom"
+    )
     ax.invert_yaxis()
     ax.set_xlim([0, 1])
     fig.tight_layout()
@@ -193,7 +204,9 @@ def plot_roc_interactive(
         )
 
     if roc_result.multi_fpr is not None and roc_result.multi_tpr is not None:
-        multi_auc = roc_result.multi_auc if roc_result.multi_auc is not None else float("nan")
+        multi_auc = (
+            roc_result.multi_auc if roc_result.multi_auc is not None else float("nan")
+        )
         fig.add_trace(
             go.Scatter(
                 x=roc_result.multi_fpr,

--- a/visualization/roc_plot.py
+++ b/visualization/roc_plot.py
@@ -145,26 +145,27 @@ def plot_auc_ranking(
     ax.axvline(x=0.5, color=palette[2], linestyle="--", alpha=0.6)
     ax.axvline(x=0.7, color=palette[0], linestyle="--", alpha=0.6)
     ax.invert_yaxis()
-    # Use transAxes so y position is independent of feature count and invert_yaxis.
-    # y=0.05 sits just above the x-axis without touching it.
-    ax.text(
-        0.51,
-        0.05,
-        "Random",
-        color=palette[2],
-        fontsize=7.5,
-        va="bottom",
-        transform=ax.transAxes,
-    )
-    ax.text(
-        0.71,
-        0.05,
-        "Good",
-        color=palette[0],
-        fontsize=7.5,
-        va="bottom",
-        transform=ax.transAxes,
-    )
+    from matplotlib.lines import Line2D
+
+    legend_handles = [
+        Line2D(
+            [0],
+            [0],
+            color=palette[2],
+            linestyle="--",
+            alpha=0.8,
+            label="Random (AUC=0.5)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            color=palette[0],
+            linestyle="--",
+            alpha=0.8,
+            label="Good (AUC≥0.7)",
+        ),
+    ]
+    ax.legend(handles=legend_handles, loc="upper right", fontsize=8, framealpha=0.85)
     ax.set_xlim([0, 1])
     fig.tight_layout()
     return fig

--- a/visualization/theme.py
+++ b/visualization/theme.py
@@ -127,6 +127,28 @@ def apply_publication_style(theme: str = "light") -> None:
     )
 
 
+def apply_publication_export_style(theme: str = "light") -> None:
+    """
+    Apply publication-grade export rcParams for batch report generation.
+
+    Builds on ``apply_publication_style`` then overrides with journal-grade
+    settings: Arial font, 300 DPI, and tighter typographic sizes.
+
+    Intended for ``run_from_config.py`` batch exports — GUI preview should
+    continue using ``apply_publication_style`` for speed.
+
+    Corresponds to R function: N/A (MetaboAnalyst uses fixed R device settings).
+    """
+    apply_publication_style(theme)
+    plt.rcParams.update(
+        {
+            "font.family": "Arial",
+            "savefig.dpi": 300,
+            "figure.dpi": 300,
+        }
+    )
+
+
 def get_group_colors(theme: str = "light", n_groups: int | None = None) -> list[str]:
     """
     Return hex color list for the given theme and number of groups.

--- a/visualization/vip_plot.py
+++ b/visualization/vip_plot.py
@@ -82,7 +82,9 @@ def plot_vip(
 
     if has_heatmap:
         gs = GridSpec(
-            1, 3, figure=fig,
+            1,
+            3,
+            figure=fig,
             width_ratios=[10, 1.2, 0.3],
             wspace=0.08,
         )
@@ -98,7 +100,9 @@ def plot_vip(
     ax.grid(True, axis="y", color=config["grid"], linewidth=0.5, zorder=0)
 
     for y_idx, value in zip(y_pos, vip_vals):
-        ax.hlines(y_idx, xmin=0, xmax=value, color=config["grid"], linewidth=1.0, zorder=2)
+        ax.hlines(
+            y_idx, xmin=0, xmax=value, color=config["grid"], linewidth=1.0, zorder=2
+        )
 
     ax.scatter(vip_vals, y_pos, c=palette[0], s=45, zorder=3, edgecolors="none")
     ax.set_yticks(y_pos)
@@ -117,10 +121,14 @@ def plot_vip(
         labels_arr = labels.values if hasattr(labels, "values") else np.asarray(labels)
         groups = sorted(set(labels_arr))
         features_in_order = list(vip_df["Feature"])
-        valid_features = [feature for feature in features_in_order if feature in data.columns]
+        valid_features = [
+            feature for feature in features_in_order if feature in data.columns
+        ]
 
         if valid_features:
-            group_means = pd.DataFrame(index=valid_features, columns=groups, dtype=float)
+            group_means = pd.DataFrame(
+                index=valid_features, columns=groups, dtype=float
+            )
             for group in groups:
                 mask = labels_arr == group
                 group_means[group] = data.loc[mask, valid_features].mean(axis=0).values
@@ -194,6 +202,7 @@ def plot_vip(
             for spine in ax_cb.spines.values():
                 spine.set_linewidth(0.5)
 
+    fig.suptitle("PLS-DA VIP Scores", fontsize=12, fontweight="bold", y=1.01)
     if not has_heatmap:
         fig.tight_layout()
     return fig

--- a/visualization/volcano_plot.py
+++ b/visualization/volcano_plot.py
@@ -57,7 +57,9 @@ def plot_volcano(
 
     result_df = volcano_result.result_df
     fc_thresh = volcano_result.fc_thresh
-    log2_fc_thresh = float(getattr(volcano_result, "log2_fc_thresh", np.log2(fc_thresh)))
+    log2_fc_thresh = float(
+        getattr(volcano_result, "log2_fc_thresh", np.log2(fc_thresh))
+    )
     p_thresh = volcano_result.p_thresh
     use_fdr = bool(getattr(volcano_result, "use_fdr", False))
     fdr_method = str(getattr(volcano_result, "fdr_method", "fdr_bh"))
@@ -76,35 +78,63 @@ def plot_volcano(
     down_mask = significant & (log2fc <= -log2_thresh)
     nonsig_mask = ~significant
 
-    ax.scatter(log2fc[nonsig_mask], neg_log10p[nonsig_mask],
-               c=config["grid"], alpha=0.5, s=20, label="Not significant")
-    ax.scatter(log2fc[up_mask], neg_log10p[up_mask],
-               c=palette[0], alpha=0.75, s=30, label="Up-regulated")
-    ax.scatter(log2fc[down_mask], neg_log10p[down_mask],
-               c="#4393C3", alpha=0.75, s=30, label="Down-regulated")
+    ax.scatter(
+        log2fc[nonsig_mask],
+        neg_log10p[nonsig_mask],
+        c=config["grid"],
+        alpha=0.5,
+        s=20,
+        label="Not significant",
+    )
+    ax.scatter(
+        log2fc[up_mask],
+        neg_log10p[up_mask],
+        c=palette[0],
+        alpha=0.75,
+        s=30,
+        label="Up-regulated",
+    )
+    ax.scatter(
+        log2fc[down_mask],
+        neg_log10p[down_mask],
+        c="#4393C3",
+        alpha=0.75,
+        s=30,
+        label="Down-regulated",
+    )
 
     threshold_color = palette[1]
-    ax.axhline(-np.log10(p_thresh), ls="--", c=threshold_color, alpha=0.7, linewidth=0.9)
+    ax.axhline(
+        -np.log10(p_thresh), ls="--", c=threshold_color, alpha=0.7, linewidth=0.9
+    )
     ax.axvline(log2_thresh, ls="--", c=threshold_color, alpha=0.7, linewidth=0.9)
     ax.axvline(-log2_thresh, ls="--", c=threshold_color, alpha=0.7, linewidth=0.9)
 
-    rank_col = "pvalue_adj" if use_fdr and "pvalue_adj" in result_df.columns else "pvalue"
+    rank_col = (
+        "pvalue_adj" if use_fdr and "pvalue_adj" in result_df.columns else "pvalue"
+    )
     top_idx = np.argsort(result_df[rank_col].to_numpy(dtype=float))[:top_n]
     texts = []
     for idx in top_idx:
         name = features[idx]
         if len(name) > 20:
             name = f"{name[:18]}.."
-        texts.append(ax.text(log2fc[idx], neg_log10p[idx], name, fontsize=7, ha="center"))
+        texts.append(
+            ax.text(log2fc[idx], neg_log10p[idx], name, fontsize=7, ha="center")
+        )
     if texts and HAS_ADJUSTTEXT:
-        adjust_text(texts, ax=ax, arrowprops=dict(arrowstyle="-", color=config["text"], lw=0.5))
+        adjust_text(
+            texts, ax=ax, arrowprops=dict(arrowstyle="-", color=config["text"], lw=0.5)
+        )
 
     ylabel = "-log10(FDR-adjusted p-value)" if use_fdr else "-log10(p-value)"
     ax.set_xlabel("log2(Fold Change)")
     ax.set_ylabel(ylabel)
     mode_text = f"FDR={fdr_method}" if use_fdr else "raw p-value"
-    ax.set_title(f"Volcano Plot ({volcano_result.group1} vs {volcano_result.group2}, {mode_text})")
-    ax.legend(loc="best", fontsize=8)
+    ax.set_title(
+        f"Volcano Plot ({volcano_result.group1} vs {volcano_result.group2}, {mode_text})"
+    )
+    ax.legend(loc="upper right", fontsize=8)
     fig.tight_layout()
     return fig
 
@@ -148,9 +178,13 @@ def plot_volcano_interactive(
     fc_threshold = (
         fc_threshold
         if fc_threshold is not None
-        else getattr(volcano_result, "log2_fc_thresh", np.log2(volcano_result.fc_thresh))
+        else getattr(
+            volcano_result, "log2_fc_thresh", np.log2(volcano_result.fc_thresh)
+        )
     )
-    pval_threshold = pval_threshold if pval_threshold is not None else volcano_result.p_thresh
+    pval_threshold = (
+        pval_threshold if pval_threshold is not None else volcano_result.p_thresh
+    )
     log2_threshold = float(fc_threshold)
 
     significant = result_df["significant"].to_numpy(dtype=bool)
@@ -168,7 +202,9 @@ def plot_volcano_interactive(
         if subset.empty:
             continue
         rank_col = "pvalue_adj" if "pvalue_adj" in subset.columns else "pvalue"
-        top_features = set(subset.nsmallest(min(top_n, len(subset)), rank_col)["Feature"].astype(str))
+        top_features = set(
+            subset.nsmallest(min(top_n, len(subset)), rank_col)["Feature"].astype(str)
+        )
         hover_text = [
             (
                 f"<b>{feature}</b><br>"
@@ -188,10 +224,17 @@ def plot_volcano_interactive(
                 x=subset["log2FC"],
                 y=subset["neg_log10p"],
                 mode="markers+text" if name != "Not significant" else "markers",
-                marker=dict(color=color, size=8 if name != "Not significant" else 6, opacity=0.85 if name != "Not significant" else 0.5),
+                marker=dict(
+                    color=color,
+                    size=8 if name != "Not significant" else 6,
+                    opacity=0.85 if name != "Not significant" else 0.5,
+                ),
                 name=name,
                 customdata=subset["Feature"].astype(str).tolist(),
-                text=[feature if str(feature) in top_features else "" for feature in subset["Feature"]],
+                text=[
+                    feature if str(feature) in top_features else ""
+                    for feature in subset["Feature"]
+                ],
                 textposition="top center",
                 hovertext=hover_text,
                 hovertemplate="%{hovertext}<extra></extra>",
@@ -206,7 +249,9 @@ def plot_volcano_interactive(
             )
         )
 
-    fig.add_hline(y=-np.log10(pval_threshold), line_dash="dash", line_color=config["text"])
+    fig.add_hline(
+        y=-np.log10(pval_threshold), line_dash="dash", line_color=config["text"]
+    )
     fig.add_vline(x=log2_threshold, line_dash="dash", line_color=config["text"])
     fig.add_vline(x=-log2_threshold, line_dash="dash", line_color=config["text"])
     fig.update_layout(


### PR DESCRIPTION
## Summary

- **Publication export profile**: `apply_publication_export_style()` added to `theme.py` — Arial font, 300 DPI. Batch export now defaults to dual PNG (300 DPI) + PDF vector output. `draft_mode: true` config opt-out for fast previews.
- **Table reorganization**: All CSV/YAML outputs moved into `REPORT_SUBDIRS` structure (`01_QC/`, `03_Feature_Selection/`, `04_Biomarker_Validation/`, `05_Supplementary/`). `pipeline_log.txt` added to `01_QC/`. `significant_features_summary.xlsx` and `Summary.csv` stay at root.
- **OPLS-DA ellipse**: Removed fill entirely — dashed border only, consistent with PLS-DA style. Avoids print contrast degradation.
- **ANOVA boxplot**: Added jittered scatter overlay (seed=42 for reproducibility) to expose data density.
- **Outlier side-by-side**: `figsize=(16,7)` ~2:1 ratio, `GridSpec` for strict alignment, `fig.align_ylabels()`.
- **adjustText**: Added to OPLS-DA S-plot and outlier annotations for label repel.
- **Legend positions**: Volcano and Density plots fixed from `loc="best"` to `loc="upper right"`.
- **Confusion matrix**: `vmax` parameter added; when multiple pairs rendered, global `vmax` locks color scale for cross-pair comparability.
- **Heatmap**: Verified existing >50 feature auto-hide logic.

## Test plan

- [ ] All 14 new tests in `tests/test_publication_export_v2.py` pass
- [ ] `tests/test_publication_batch_report_smoke.py` passes with updated expected paths
- [ ] Full suite: 503 passed, 3 pre-existing GUI failures on `test_gui_phase7_slow.py` (same on `main`)
- [ ] Manually verify a batch run produces PNG+PDF pairs in subdirectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)