### PR TITLE
[codex] Make batch PDF export opt-in

### DIFF
--- a/core/app_config.py
+++ b/core/app_config.py
@@ -342,6 +342,7 @@ class OutputConfig:
     suffix: str = ""
     auto_timestamp: bool = True
     export_top_n: int | None = None
+    save_pdf: bool = False
     extras: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -350,12 +351,13 @@ class OutputConfig:
         extras = {
             key: copy.deepcopy(value)
             for key, value in data.items()
-            if key not in {"suffix", "auto_timestamp", "export_top_n"}
+            if key not in {"suffix", "auto_timestamp", "export_top_n", "save_pdf"}
         }
         return cls(
             suffix=str(mapping.get("suffix", "")),
             auto_timestamp=bool(mapping.get("auto_timestamp", True)),
             export_top_n=mapping.get("export_top_n"),
+            save_pdf=bool(mapping.get("save_pdf", False)),
             extras=extras,
         )
 
@@ -365,6 +367,7 @@ class OutputConfig:
             "suffix": self.suffix,
             "auto_timestamp": self.auto_timestamp,
             "export_top_n": self.export_top_n,
+            "save_pdf": self.save_pdf,
         }
         data.update(copy.deepcopy(self.extras))
         return data

--- a/core/input_resolver.py
+++ b/core/input_resolver.py
@@ -25,9 +25,18 @@ class SheetPreference:
 
 
 SHEET_PREFERENCES: tuple[SheetPreference, ...] = (
+    SheetPreference(
+        "QC_Batch_Scaling_result",
+        ("QC_Batch_Scaling_result", "Batch_scaling"),
+        ("qcbatch", "batchscaling", "batch"),
+    ),
+    SheetPreference(
+        "SpecNorm_PQN_Result",
+        ("SpecNorm_PQN_Result",),
+        ("specnormpqn", "specnorm"),
+    ),
     SheetPreference("PQN_Result", ("PQN_Result",), ("pqn",)),
     SheetPreference("SpecNorm_Result", ("SpecNorm_Result",), ("specnorm",)),
-    SheetPreference("Batch_scaling", ("Batch_scaling",), ("batch", "batchscaling")),
     SheetPreference(
         "QC LOESS result",
         ("QC LOESS result", "QC_LOESS_result", "QCLOESS"),
@@ -77,7 +86,8 @@ def resolve_primary_sheet_name_from_names(file_name: str, sheet_names: Sequence[
 
     raise ValueError(
         "Could not resolve a usable data worksheet. Expected one of: "
-        "PQN_Result, SpecNorm_Result, Batch_scaling, QC LOESS result, ISTD, RawIntensity."
+        "QC_Batch_Scaling_result, SpecNorm_PQN_Result, PQN_Result, "
+        "SpecNorm_Result, Batch_scaling, QC LOESS result, ISTD, RawIntensity."
     )
 
 

--- a/core/param_specs.py
+++ b/core/param_specs.py
@@ -406,6 +406,13 @@ PARAM_SPECS: dict[str, ParamSpec] = {
         scope="shared-readonly",
         gui_label="Top-N export limit",
     ),
+    "output.save_pdf": ParamSpec(
+        path="output.save_pdf",
+        default=False,
+        value_type=bool,
+        scope="shared-readonly",
+        gui_label="Save PDF figures",
+    ),
     "spec_norm.factor_column": ParamSpec(
         path="spec_norm.factor_column",
         default=None,

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -94,12 +94,17 @@ def _ensure_report_dirs(output_dir: str) -> dict[str, Path]:
     return report_dirs
 
 
-def _save_figure(fig: Any, path: Path, *, draft_mode: bool = False) -> None:
-    """Save a matplotlib figure as PNG (and PDF in publication mode), then close."""
-    if draft_mode:
-        fig.savefig(path, dpi=150, bbox_inches="tight")
-    else:
-        fig.savefig(path, dpi=300, bbox_inches="tight")
+def _save_figure(
+    fig: Any,
+    path: Path,
+    *,
+    draft_mode: bool = False,
+    save_pdf: bool = False,
+) -> None:
+    """Save a matplotlib figure as PNG, optionally adding a PDF companion."""
+    dpi = 150 if draft_mode else 300
+    fig.savefig(path, dpi=dpi, bbox_inches="tight")
+    if save_pdf:
         fig.savefig(path.with_suffix(".pdf"), bbox_inches="tight")
     plt.close(fig)
 
@@ -622,7 +627,9 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     os.makedirs(output_dir, exist_ok=True)
     report_dirs = _ensure_report_dirs(output_dir)
 
-    draft_mode = bool(cfg.get("output", {}).get("draft_mode", False))
+    output_cfg = cfg.get("output", {})
+    draft_mode = bool(output_cfg.get("draft_mode", False))
+    save_pdf = bool(output_cfg.get("save_pdf", False))
     if not draft_mode:
         from visualization.theme import apply_publication_export_style
 
@@ -784,7 +791,10 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     fig = plt.figure(figsize=(12, 8))
     plot_norm_comparison(pre_norm_matrix, processed, final_labels, fig=fig)
     _save_figure(
-        fig, report_dirs["qc"] / "normalization_comparison.png", draft_mode=draft_mode
+        fig,
+        report_dirs["qc"] / "normalization_comparison.png",
+        draft_mode=draft_mode,
+        save_pdf=save_pdf,
     )
     print(f"  Saved {REPORT_SUBDIRS['qc']}\\normalization_comparison.png")
 
@@ -801,7 +811,12 @@ def run_analysis(cfg: dict) -> dict[str, str]:
 
     fig = plt.figure(figsize=(10, 8))
     plot_pca_score(pca_result, pc_x=0, pc_y=1, fig=fig)
-    _save_figure(fig, report_dirs["qc"] / "pca_score_plot.png", draft_mode=draft_mode)
+    _save_figure(
+        fig,
+        report_dirs["qc"] / "pca_score_plot.png",
+        draft_mode=draft_mode,
+        save_pdf=save_pdf,
+    )
     print(f"  Saved {REPORT_SUBDIRS['qc']}\\pca_score_plot.png")
 
     # ── ANOVA ─────────────────────────────────────────────
@@ -845,7 +860,10 @@ def run_analysis(cfg: dict) -> dict[str, str]:
     fig = plt.figure(figsize=(10, 8))
     plot_anova_importance(anova_result, top_n=25, fig=fig)
     _save_figure(
-        fig, report_dirs["feature"] / "anova_importance.png", draft_mode=draft_mode
+        fig,
+        report_dirs["feature"] / "anova_importance.png",
+        draft_mode=draft_mode,
+        save_pdf=save_pdf,
     )
 
     anova_ranked = anova_result.result_df.sort_values("pvalue_adj").copy()
@@ -871,6 +889,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             heatmap_fig,
             report_dirs["global"] / "heatmap_top50.png",
             draft_mode=draft_mode,
+            save_pdf=save_pdf,
         )
         print(f"  Saved {REPORT_SUBDIRS['global']}\\heatmap_top50.png")
 
@@ -904,6 +923,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 fig,
                 report_dirs["supplementary"] / f"anova_boxplot_{g1}_vs_{g2}_top{i}.png",
                 draft_mode=draft_mode,
+                save_pdf=save_pdf,
             )
             saved_anova_boxplots += 1
     print(f"  Saved {REPORT_SUBDIRS['feature']}\\anova_importance.png")
@@ -934,6 +954,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 fig,
                 report_dirs["supplementary"] / "plsda_score_all_groups.png",
                 draft_mode=draft_mode,
+                save_pdf=save_pdf,
             )
             print(
                 f"  Saved {REPORT_SUBDIRS['supplementary']}\\plsda_score_all_groups.png"
@@ -973,6 +994,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                     fig,
                     report_dirs["feature"] / f"plsda_vip_{g1}_vs_{g2}.png",
                     draft_mode=draft_mode,
+                    save_pdf=save_pdf,
                 )
                 print(
                     f"    Saved {REPORT_SUBDIRS['feature']}\\plsda_vip_{g1}_vs_{g2}.png"
@@ -1021,6 +1043,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                     fig,
                     report_dirs["feature"] / f"oplsda_score_{g1}_vs_{g2}.png",
                     draft_mode=draft_mode,
+                    save_pdf=save_pdf,
                 )
 
                 fig = plt.figure(figsize=(8, 6))
@@ -1029,6 +1052,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                     fig,
                     report_dirs["feature"] / f"oplsda_splot_{g1}_vs_{g2}.png",
                     draft_mode=draft_mode,
+                    save_pdf=save_pdf,
                 )
 
                 print(
@@ -1147,6 +1171,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 fig,
                 report_dirs["feature"] / f"volcano_{g1}_vs_{g2}.png",
                 draft_mode=draft_mode,
+                save_pdf=save_pdf,
             )
             print(f"    Saved {REPORT_SUBDIRS['feature']}\\volcano_{g1}_vs_{g2}.png")
         except Exception as e:
@@ -1189,6 +1214,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 fig,
                 report_dirs["validation"] / f"roc_{g1}_vs_{g2}.png",
                 draft_mode=draft_mode,
+                save_pdf=save_pdf,
             )
 
             fig = plt.figure(figsize=(8, 6))
@@ -1197,6 +1223,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
                 fig,
                 report_dirs["validation"] / f"auc_ranking_{g1}_vs_{g2}.png",
                 draft_mode=draft_mode,
+                save_pdf=save_pdf,
             )
 
             print(f"    Saved {REPORT_SUBDIRS['validation']}\\roc_{g1}_vs_{g2}.png")
@@ -1224,7 +1251,10 @@ def run_analysis(cfg: dict) -> dict[str, str]:
         fig = plt.figure(figsize=(8, 6))
         plot_outlier_score(outlier_result, labels=final_labels, fig=fig)
         _save_figure(
-            fig, report_dirs["supplementary"] / "outlier_t2.png", draft_mode=draft_mode
+            fig,
+            report_dirs["supplementary"] / "outlier_t2.png",
+            draft_mode=draft_mode,
+            save_pdf=save_pdf,
         )
 
         fig = plt.figure(figsize=(8, 6))
@@ -1233,6 +1263,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             fig,
             report_dirs["supplementary"] / "outlier_dmodx.png",
             draft_mode=draft_mode,
+            save_pdf=save_pdf,
         )
         print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_t2.png")
         print(f"  Saved {REPORT_SUBDIRS['supplementary']}\\outlier_dmodx.png")
@@ -1287,6 +1318,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             fig,
             report_dirs["supplementary"] / f"rf_importance_{g1}_vs_{g2}.png",
             draft_mode=draft_mode,
+            save_pdf=save_pdf,
         )
 
         fig = plt.figure(figsize=(6, 5))
@@ -1297,6 +1329,7 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             fig,
             report_dirs["supplementary"] / f"rf_confusion_matrix_{g1}_vs_{g2}.png",
             draft_mode=draft_mode,
+            save_pdf=save_pdf,
         )
 
         print(

--- a/tests/test_analysis_edgecases.py
+++ b/tests/test_analysis_edgecases.py
@@ -3,6 +3,13 @@ import pandas as pd
 import pytest
 
 
+def _all_figure_text(fig):
+    return "\n".join(
+        [text.get_text() for text in fig.texts]
+        + [text.get_text() for ax in fig.axes for text in ax.texts]
+    )
+
+
 def test_feature_boxplot_displays_ttest_and_pvalue_for_two_groups():
     from visualization.anova_plot import plot_feature_boxplot
 
@@ -14,8 +21,7 @@ def test_feature_boxplot_displays_ttest_and_pvalue_for_two_groups():
     labels = pd.Series(["Tumor"] * 4 + ["Adjacent"] * 4)
 
     fig = plot_feature_boxplot(df, labels, "FeatA")
-    # Stat annotation is placed on the figure margin (fig.texts), not ax.texts
-    all_text = "\n".join(t.get_text() for t in fig.texts)
+    all_text = _all_figure_text(fig)
 
     assert "P =" in all_text
     assert "T-test" in all_text
@@ -32,7 +38,7 @@ def test_feature_boxplot_uses_kruskal_metadata_for_three_groups():
     labels = pd.Series(["A"] * 3 + ["B"] * 3 + ["C"] * 3)
 
     fig = plot_feature_boxplot(df, labels, "FeatA", annotation_method="kruskal")
-    all_text = "\n".join(t.get_text() for t in fig.texts)
+    all_text = _all_figure_text(fig)
 
     assert "P =" in all_text
     assert "Kruskal-Wallis" in all_text
@@ -51,7 +57,7 @@ def test_feature_boxplot_uses_mannwhitney_metadata_for_two_groups():
     labels = pd.Series(["Tumor"] * 3 + ["Adjacent"] * 3)
 
     fig = plot_feature_boxplot(df, labels, "FeatA", annotation_method="mannwhitney")
-    all_text = "\n".join(t.get_text() for t in fig.texts)
+    all_text = _all_figure_text(fig)
 
     assert "P =" in all_text
     assert "Mann-Whitney U" in all_text

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -41,6 +41,7 @@ def test_normalize_config_merges_shared_defaults() -> None:
     assert normalized["analysis"]["volcano"]["parametric_test_default"] == "welch"
     assert normalized["analysis"]["volcano"]["test"] == "welch"
     assert normalized["output"]["auto_timestamp"] is True
+    assert normalized["output"]["save_pdf"] is False
 
 
 def test_load_yaml_config_allows_partial_gui_preset(tmp_path: Path) -> None:
@@ -53,7 +54,7 @@ def test_load_yaml_config_allows_partial_gui_preset(tmp_path: Path) -> None:
                     "qc_rsd_enabled": True,
                 },
                 "groups": {"include": ["Tumor", "Normal"]},
-                "output": {"suffix": "gui_preset"},
+                "output": {"suffix": "gui_preset", "save_pdf": True},
             },
             allow_unicode=True,
             sort_keys=False,
@@ -67,6 +68,7 @@ def test_load_yaml_config_allows_partial_gui_preset(tmp_path: Path) -> None:
     assert config.groups["include"] == ["Tumor", "Normal"]
     assert config.analysis["pca"]["n_components"] == 5
     assert config.output.suffix == "gui_preset"
+    assert config.output.save_pdf is True
     assert config.spec_norm == {}
     assert config.source_sections == frozenset({"pipeline", "groups", "output"})
     assert config.to_pipeline_params()["qc_rsd_enabled"] is True

--- a/tests/test_publication_batch_report_smoke.py
+++ b/tests/test_publication_batch_report_smoke.py
@@ -446,6 +446,8 @@ def test_publication_report_smoke_layout_and_pruning(
     for file_path in expected_files:
         assert file_path.is_file(), f"missing report file: {file_path}"
 
+    assert not list(output_dir.rglob("*.pdf")), "PDF figures should be opt-in"
+
     for file_path in legacy_files:
         assert not file_path.exists(), (
             f"legacy output should not be emitted: {file_path}"

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -112,6 +112,19 @@ class TestAnovaBoxplotJitter:
         )
         plt.close(fig)
 
+    def test_boxplot_fliers_are_hidden_when_raw_points_are_overlaid(self):
+        from visualization.anova_plot import _draw_r_style_boxplot
+        from visualization.theme import COLORS
+
+        fig, ax = plt.subplots()
+        config = COLORS["light"]
+        data = [np.array([1.0, 2.0, 3.0, 4.0, 100.0])]
+        _draw_r_style_boxplot(ax, data, ["A"], ["#E64B35"], config)
+
+        flier_lines = [line for line in ax.lines if line.get_marker() == "o"]
+        assert flier_lines == []
+        plt.close(fig)
+
 class TestNormalizationComparisonAxes:
     def test_group_boxplot_scientific_scale_is_folded_into_ylabel(self):
         import pandas as pd

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -142,6 +142,37 @@ class TestAnovaBoxplotJitter:
         plt.close(fig)
 
 
+class TestNormalizationComparisonAxes:
+    def test_group_boxplot_scientific_scale_is_folded_into_ylabel(self):
+        import pandas as pd
+
+        from visualization.norm_preview import plot_norm_comparison
+
+        before = pd.DataFrame(
+            {
+                "F1": [1.2e10, 2.4e10, 3.6e10, 4.8e10],
+                "F2": [1.4e10, 2.6e10, 3.8e10, 5.0e10],
+            }
+        )
+        after = pd.DataFrame(
+            {
+                "F1": [0.8, 0.9, 1.1, 1.2],
+                "F2": [0.7, 1.0, 1.0, 1.3],
+            }
+        )
+        labels = pd.Series(["Exposure", "Exposure", "Normal", "Normal"])
+
+        fig = plot_norm_comparison(before, after, labels)
+        fig.canvas.draw()
+
+        before_box_ax = fig.axes[0]
+        after_box_ax = fig.axes[1]
+        assert before_box_ax.get_ylabel() == r"Intensity ($\times 10^{10}$)"
+        assert before_box_ax.yaxis.get_offset_text().get_text() == ""
+        assert after_box_ax.get_ylabel() == "Intensity"
+        plt.close(fig)
+
+
 class TestOutlierPlotLayout:
     def test_outlier_score_figsize_2_to_1(self):
         from unittest.mock import MagicMock

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -112,64 +112,39 @@ class TestAnovaBoxplotJitter:
         )
         plt.close(fig)
 
-    def test_scientific_scale_is_folded_into_ylabel(self):
-        import pandas as pd
-
-        from visualization.anova_plot import plot_feature_boxplot
-
-        df = pd.DataFrame(
-            {
-                "5-hmdC": [
-                    1.2e5,
-                    2.4e5,
-                    3.6e5,
-                    4.8e5,
-                    5.0e5,
-                    6.2e5,
-                    7.4e5,
-                    8.6e5,
-                ]
-            }
-        )
-        labels = pd.Series(["Exposure"] * 4 + ["Normal"] * 4)
-
-        fig = plot_feature_boxplot(df, labels, "5-hmdC")
-        ax = fig.axes[0]
-        fig.canvas.draw()
-
-        assert ax.get_ylabel() == r"Intensity ($\times 10^{5}$)"
-        assert ax.yaxis.get_offset_text().get_text() == ""
-        plt.close(fig)
-
-
 class TestNormalizationComparisonAxes:
     def test_group_boxplot_scientific_scale_is_folded_into_ylabel(self):
         import pandas as pd
 
         from visualization.norm_preview import plot_norm_comparison
 
-        before = pd.DataFrame(
-            {
-                "F1": [1.2e10, 2.4e10, 3.6e10, 4.8e10],
-                "F2": [1.4e10, 2.6e10, 3.8e10, 5.0e10],
-            }
-        )
+        before_values = np.full((6, 20), 1.0e8)
+        before_values[:, :18] += np.arange(18) * 5.0e6
+        before_values[0, 18] = 4.0e9
+        before_values[5, 19] = 5.0e9
+        before = pd.DataFrame(before_values)
         after = pd.DataFrame(
-            {
-                "F1": [0.8, 0.9, 1.1, 1.2],
-                "F2": [0.7, 1.0, 1.0, 1.3],
-            }
+            np.linspace(0.7, 1.3, before_values.size).reshape(before_values.shape)
         )
-        labels = pd.Series(["Exposure", "Exposure", "Normal", "Normal"])
+        labels = pd.Series(["Exposure"] * 3 + ["Normal"] * 3)
 
         fig = plot_norm_comparison(before, after, labels)
         fig.canvas.draw()
 
         before_box_ax = fig.axes[0]
         after_box_ax = fig.axes[1]
-        assert before_box_ax.get_ylabel() == r"Intensity ($\times 10^{10}$)"
+        before_density_ax = fig.axes[2]
+        after_density_ax = fig.axes[3]
+
+        assert before_box_ax.get_ylabel() == r"Intensity ($\times 10^{8}$)"
         assert before_box_ax.yaxis.get_offset_text().get_text() == ""
         assert after_box_ax.get_ylabel() == "Intensity"
+        assert before_density_ax.get_xlabel() == r"Intensity ($\times 10^{9}$)"
+        assert before_density_ax.get_ylabel() == r"Density ($\times 10^{-9}$)"
+        assert before_density_ax.xaxis.get_offset_text().get_text() == ""
+        assert before_density_ax.yaxis.get_offset_text().get_text() == ""
+        assert after_density_ax.get_xlabel() == "Intensity"
+        assert after_density_ax.xaxis.get_offset_text().get_text() == ""
         plt.close(fig)
 
 

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -112,6 +112,35 @@ class TestAnovaBoxplotJitter:
         )
         plt.close(fig)
 
+    def test_scientific_scale_is_folded_into_ylabel(self):
+        import pandas as pd
+
+        from visualization.anova_plot import plot_feature_boxplot
+
+        df = pd.DataFrame(
+            {
+                "5-hmdC": [
+                    1.2e5,
+                    2.4e5,
+                    3.6e5,
+                    4.8e5,
+                    5.0e5,
+                    6.2e5,
+                    7.4e5,
+                    8.6e5,
+                ]
+            }
+        )
+        labels = pd.Series(["Exposure"] * 4 + ["Normal"] * 4)
+
+        fig = plot_feature_boxplot(df, labels, "5-hmdC")
+        ax = fig.axes[0]
+        fig.canvas.draw()
+
+        assert ax.get_ylabel() == r"Intensity ($\times 10^{5}$)"
+        assert ax.yaxis.get_offset_text().get_text() == ""
+        plt.close(fig)
+
 
 class TestOutlierPlotLayout:
     def test_outlier_score_figsize_2_to_1(self):

--- a/tests/test_publication_export_v2.py
+++ b/tests/test_publication_export_v2.py
@@ -31,14 +31,24 @@ class TestPublicationExportStyle:
         assert plt.rcParams["legend.frameon"] is False
 
 
-class TestSaveFigureDualOutput:
-    def test_publication_mode_creates_png_and_pdf(self, tmp_path):
+class TestSaveFigureOutputFormats:
+    def test_publication_mode_defaults_to_png_only(self, tmp_path):
         from scripts.run_from_config import _save_figure
 
         fig = plt.figure()
         fig.add_subplot(111).plot([1, 2], [3, 4])
         out = tmp_path / "test.png"
         _save_figure(fig, out, draft_mode=False)
+        assert out.exists()
+        assert not out.with_suffix(".pdf").exists()
+
+    def test_save_pdf_option_creates_png_and_pdf(self, tmp_path):
+        from scripts.run_from_config import _save_figure
+
+        fig = plt.figure()
+        fig.add_subplot(111).plot([1, 2], [3, 4])
+        out = tmp_path / "test.png"
+        _save_figure(fig, out, draft_mode=False, save_pdf=True)
         assert out.exists()
         assert out.with_suffix(".pdf").exists()
 

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from core.input_resolver import resolve_primary_sheet_name_from_names
+from core.input_resolver import read_input_table, resolve_primary_sheet_name_from_names
 from scripts.run_from_config import (
     _export_significant_features_excel,
     load_data,
@@ -390,6 +390,73 @@ def test_resolve_primary_sheet_name_prefers_filename_hint_with_priority():
     )
 
     assert resolved == "SpecNorm_Result"
+
+
+def test_resolve_primary_sheet_name_prefers_final_dnp_batch_result():
+    resolved = resolve_primary_sheet_name_from_names(
+        "single_or_multi_batch_dnp_export.xlsx",
+        [
+            "Overview",
+            "PQN_Result",
+            "SpecNorm_PQN_Result",
+            "QC_Batch_Scaling_result",
+            "SampleInfo",
+        ],
+    )
+
+    assert resolved == "QC_Batch_Scaling_result"
+
+
+def test_resolve_primary_sheet_name_prefers_specnorm_pqn_when_batch_result_absent():
+    resolved = resolve_primary_sheet_name_from_names(
+        "single_batch_dnp_export.xlsx",
+        ["Overview", "PQN_Result", "SpecNorm_PQN_Result", "SampleInfo"],
+    )
+
+    assert resolved == "SpecNorm_PQN_Result"
+
+
+def test_resolve_primary_sheet_name_keeps_pqn_as_dnp_fallback():
+    resolved = resolve_primary_sheet_name_from_names(
+        "single_batch_dnp_export.xlsx",
+        ["Overview", "PQN_Result", "SampleInfo"],
+    )
+
+    assert resolved == "PQN_Result"
+
+
+def test_resolve_primary_sheet_name_keeps_legacy_batch_scaling_alias():
+    resolved = resolve_primary_sheet_name_from_names(
+        "legacy_batch_export.xlsx",
+        ["Overview", "PQN_Result", "Batch_scaling", "SampleInfo"],
+    )
+
+    assert resolved == "Batch_scaling"
+
+
+def test_read_input_table_loads_specnorm_pqn_sheet_without_fallback(tmp_path: Path):
+    xlsx_path = tmp_path / "dnp_single_batch_specnorm_pqn.xlsx"
+    overview_df = pd.DataFrame({"Status": ["not data"]})
+    matrix_df = pd.DataFrame(
+        {
+            "Mz/RT": ["Sample_Type", "100.1/1.1"],
+            "Sample_A": ["Exposure", 1.0],
+            "Sample_B": ["Normal", 2.0],
+        }
+    )
+    with pd.ExcelWriter(xlsx_path) as writer:
+        overview_df.to_excel(writer, sheet_name="Overview", index=False)
+        matrix_df.to_excel(writer, sheet_name="SpecNorm_PQN_Result", index=False)
+        _sample_info(["Sample_A", "Sample_B"], ["Exposure", "Normal"]).to_excel(
+            writer,
+            sheet_name="SampleInfo",
+            index=False,
+        )
+
+    loaded = read_input_table(str(xlsx_path))
+
+    assert loaded.sheet_name == "SpecNorm_PQN_Result"
+    assert list(loaded.table.columns) == ["Mz/RT", "Sample_A", "Sample_B"]
 
 
 def test_summary_export_keeps_features_with_zero_significant_hits(tmp_path: Path):

--- a/visualization/anova_plot.py
+++ b/visualization/anova_plot.py
@@ -149,7 +149,7 @@ def _draw_r_style_boxplot(
             widths=0.55,
             patch_artist=True,
             showmeans=False,
-            showfliers=True,
+            showfliers=False,
             boxprops=dict(
                 facecolor=color, edgecolor=config["axes_line"], linewidth=1.0
             ),

--- a/visualization/anova_plot.py
+++ b/visualization/anova_plot.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
+from matplotlib.ticker import FuncFormatter
 from scipy.stats import f_oneway, kruskal, mannwhitneyu, ttest_ind
 
 from visualization.theme import COLORS, apply_publication_style, get_group_colors
@@ -196,6 +197,44 @@ def _draw_r_style_boxplot(
     ax.spines["bottom"].set_linewidth(0.8)
 
 
+def _set_intensity_ylabel(
+    ax,
+    data_by_group: list[np.ndarray],
+    *,
+    fontsize: float = 10,
+) -> None:
+    """Move scientific y-axis scaling into the axis label for readability."""
+    finite_chunks = []
+    for values in data_by_group:
+        if len(values) == 0:
+            continue
+        clean = np.asarray(values, dtype=float)
+        finite_chunks.append(clean[np.isfinite(clean)])
+
+    if not finite_chunks:
+        ax.set_ylabel("Intensity", fontsize=fontsize)
+        return
+
+    finite_values = np.concatenate(finite_chunks)
+    if finite_values.size == 0:
+        ax.set_ylabel("Intensity", fontsize=fontsize)
+        return
+
+    max_abs = float(np.max(np.abs(finite_values)))
+    use_scientific = max_abs >= 1e4 or 0 < max_abs < 1e-3
+    if not use_scientific:
+        ax.set_ylabel("Intensity", fontsize=fontsize)
+        return
+
+    exponent = int(np.floor(np.log10(max_abs)))
+    scale = 10.0**exponent
+    ax.yaxis.set_major_formatter(
+        FuncFormatter(lambda value, _position: f"{value / scale:g}")
+    )
+    ax.yaxis.offsetText.set_visible(False)
+    ax.set_ylabel(fr"Intensity ($\times 10^{{{exponent}}}$)", fontsize=fontsize)
+
+
 def plot_feature_boxplot(
     df: pd.DataFrame,
     labels,
@@ -257,7 +296,7 @@ def plot_feature_boxplot(
     _draw_r_style_boxplot(ax, data_by_group, groups, box_colors, config)
 
     ax.set_title(str(feature_name), fontsize=11, fontweight="bold")
-    ax.set_ylabel("Value", fontsize=10)
+    _set_intensity_ylabel(ax, data_by_group, fontsize=10)
     ax.tick_params(axis="x", labelsize=8)
 
     stat_text = _build_stat_annotation(plot_data, annotation_method=annotation_method)

--- a/visualization/anova_plot.py
+++ b/visualization/anova_plot.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
-from matplotlib.ticker import FuncFormatter
 from scipy.stats import f_oneway, kruskal, mannwhitneyu, ttest_ind
 
 from visualization.theme import COLORS, apply_publication_style, get_group_colors
@@ -197,44 +196,6 @@ def _draw_r_style_boxplot(
     ax.spines["bottom"].set_linewidth(0.8)
 
 
-def _set_intensity_ylabel(
-    ax,
-    data_by_group: list[np.ndarray],
-    *,
-    fontsize: float = 10,
-) -> None:
-    """Move scientific y-axis scaling into the axis label for readability."""
-    finite_chunks = []
-    for values in data_by_group:
-        if len(values) == 0:
-            continue
-        clean = np.asarray(values, dtype=float)
-        finite_chunks.append(clean[np.isfinite(clean)])
-
-    if not finite_chunks:
-        ax.set_ylabel("Intensity", fontsize=fontsize)
-        return
-
-    finite_values = np.concatenate(finite_chunks)
-    if finite_values.size == 0:
-        ax.set_ylabel("Intensity", fontsize=fontsize)
-        return
-
-    max_abs = float(np.max(np.abs(finite_values)))
-    use_scientific = max_abs >= 1e4 or 0 < max_abs < 1e-3
-    if not use_scientific:
-        ax.set_ylabel("Intensity", fontsize=fontsize)
-        return
-
-    exponent = int(np.floor(np.log10(max_abs)))
-    scale = 10.0**exponent
-    ax.yaxis.set_major_formatter(
-        FuncFormatter(lambda value, _position: f"{value / scale:g}")
-    )
-    ax.yaxis.offsetText.set_visible(False)
-    ax.set_ylabel(fr"Intensity ($\times 10^{{{exponent}}}$)", fontsize=fontsize)
-
-
 def plot_feature_boxplot(
     df: pd.DataFrame,
     labels,
@@ -296,7 +257,7 @@ def plot_feature_boxplot(
     _draw_r_style_boxplot(ax, data_by_group, groups, box_colors, config)
 
     ax.set_title(str(feature_name), fontsize=11, fontweight="bold")
-    _set_intensity_ylabel(ax, data_by_group, fontsize=10)
+    ax.set_ylabel("Value", fontsize=10)
     ax.tick_params(axis="x", labelsize=8)
 
     stat_text = _build_stat_annotation(plot_data, annotation_method=annotation_method)

--- a/visualization/norm_preview.py
+++ b/visualization/norm_preview.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
 from matplotlib.patches import Patch
+from matplotlib.ticker import FuncFormatter
 from scipy.stats import gaussian_kde
 
 from visualization.theme import apply_publication_style, get_group_colors
@@ -197,11 +198,40 @@ def _draw_group_box(ax, df, labels_arr, groups, color_map, title: str) -> None:
 
     ax.set_xticks(positions)
     ax.set_xticklabels([str(group)[:12] for group in groups], fontsize=8)
-    ax.set_ylabel("Intensity", fontsize=9.5)
+    _set_intensity_ylabel(ax, data_by_group, fontsize=9.5)
     ax.tick_params(axis="x", pad=2)
     ax.grid(axis="y", alpha=0.12, linewidth=0.6)
     ax.set_xlabel("Group", fontsize=9)
     ax.set_xlim(0.5, len(groups) + 0.5)
+
+
+def _set_intensity_ylabel(ax, data_by_group: list[np.ndarray], *, fontsize: float) -> None:
+    """Move scientific y-axis scaling into the axis label for readability."""
+    finite_chunks = []
+    for values in data_by_group:
+        clean = np.asarray(values, dtype=float)
+        clean = clean[np.isfinite(clean)]
+        if clean.size:
+            finite_chunks.append(clean)
+
+    if not finite_chunks:
+        ax.set_ylabel("Intensity", fontsize=fontsize)
+        return
+
+    finite_values = np.concatenate(finite_chunks)
+    max_abs = float(np.max(np.abs(finite_values)))
+    use_scientific = max_abs >= 1e4 or 0 < max_abs < 1e-3
+    if not use_scientific:
+        ax.set_ylabel("Intensity", fontsize=fontsize)
+        return
+
+    exponent = int(np.floor(np.log10(max_abs)))
+    scale = 10.0**exponent
+    ax.yaxis.set_major_formatter(
+        FuncFormatter(lambda value, _position: f"{value / scale:g}")
+    )
+    ax.yaxis.offsetText.set_visible(False)
+    ax.set_ylabel(fr"Intensity ($\times 10^{{{exponent}}}$)", fontsize=fontsize)
 
 
 def _draw_density(ax, df, labels_arr, groups, color_map, x_range, title: str) -> None:

--- a/visualization/norm_preview.py
+++ b/visualization/norm_preview.py
@@ -63,8 +63,10 @@ def plot_norm_comparison(
     palette = get_group_colors(theme, len(groups))
     color_map = dict(zip(groups, palette))
 
-    before_min, before_max = _shared_value_limits(before_df, after_df)
-    density_x = np.linspace(before_min, before_max, 240)
+    before_min, before_max = _shared_value_limits(before_df)
+    after_min, after_max = _shared_value_limits(after_df)
+    before_density_x = np.linspace(before_min, before_max, 240)
+    after_density_x = np.linspace(after_min, after_max, 240)
 
     gs = fig.add_gridspec(
         2,
@@ -86,13 +88,25 @@ def plot_norm_comparison(
 
     ax3 = fig.add_subplot(gs[1, 0])
     _draw_density(
-        ax3, before_df, labels_arr, groups, color_map, density_x, "Before density"
+        ax3,
+        before_df,
+        labels_arr,
+        groups,
+        color_map,
+        before_density_x,
+        "Before density",
     )
     ax3.set_title("Before density", fontsize=10.5, fontweight="bold", pad=8)
 
     ax4 = fig.add_subplot(gs[1, 1])
     _draw_density(
-        ax4, after_df, labels_arr, groups, color_map, density_x, "After density"
+        ax4,
+        after_df,
+        labels_arr,
+        groups,
+        color_map,
+        after_density_x,
+        "After density",
     )
     ax4.set_title("After density", fontsize=10.5, fontweight="bold", pad=8)
 
@@ -198,40 +212,45 @@ def _draw_group_box(ax, df, labels_arr, groups, color_map, title: str) -> None:
 
     ax.set_xticks(positions)
     ax.set_xticklabels([str(group)[:12] for group in groups], fontsize=8)
-    _set_intensity_ylabel(ax, data_by_group, fontsize=9.5)
     ax.tick_params(axis="x", pad=2)
     ax.grid(axis="y", alpha=0.12, linewidth=0.6)
     ax.set_xlabel("Group", fontsize=9)
     ax.set_xlim(0.5, len(groups) + 0.5)
+    _fold_scientific_axis_label(ax, axis="y", label="Intensity", fontsize=9.5)
 
 
-def _set_intensity_ylabel(ax, data_by_group: list[np.ndarray], *, fontsize: float) -> None:
-    """Move scientific y-axis scaling into the axis label for readability."""
-    finite_chunks = []
-    for values in data_by_group:
-        clean = np.asarray(values, dtype=float)
-        clean = clean[np.isfinite(clean)]
-        if clean.size:
-            finite_chunks.append(clean)
+def _fold_scientific_axis_label(
+    ax,
+    *,
+    axis: str,
+    label: str,
+    fontsize: float | None = None,
+) -> None:
+    """Move visible scientific scaling into an axis label."""
+    if axis == "x":
+        values = np.asarray(ax.get_xlim(), dtype=float)
+        formatter_axis = ax.xaxis
+        set_label = ax.set_xlabel
+    elif axis == "y":
+        values = np.asarray(ax.get_ylim(), dtype=float)
+        formatter_axis = ax.yaxis
+        set_label = ax.set_ylabel
+    else:
+        raise ValueError("axis must be 'x' or 'y'.")
 
-    if not finite_chunks:
-        ax.set_ylabel("Intensity", fontsize=fontsize)
-        return
-
-    finite_values = np.concatenate(finite_chunks)
-    max_abs = float(np.max(np.abs(finite_values)))
+    max_abs = float(np.max(np.abs(values[np.isfinite(values)])))
     use_scientific = max_abs >= 1e4 or 0 < max_abs < 1e-3
     if not use_scientific:
-        ax.set_ylabel("Intensity", fontsize=fontsize)
+        set_label(label, fontsize=fontsize)
         return
 
     exponent = int(np.floor(np.log10(max_abs)))
     scale = 10.0**exponent
-    ax.yaxis.set_major_formatter(
+    formatter_axis.set_major_formatter(
         FuncFormatter(lambda value, _position: f"{value / scale:g}")
     )
-    ax.yaxis.offsetText.set_visible(False)
-    ax.set_ylabel(fr"Intensity ($\times 10^{{{exponent}}}$)", fontsize=fontsize)
+    formatter_axis.offsetText.set_visible(False)
+    set_label(fr"{label} ($\times 10^{{{exponent}}}$)", fontsize=fontsize)
 
 
 def _draw_density(ax, df, labels_arr, groups, color_map, x_range, title: str) -> None:
@@ -276,6 +295,8 @@ def _draw_density(ax, df, labels_arr, groups, color_map, x_range, title: str) ->
     ax.set_xlim(float(x_range[0]), float(x_range[-1]))
     if y_max > 0:
         ax.set_ylim(0, y_max * 1.08)
+    _fold_scientific_axis_label(ax, axis="x", label="Intensity")
+    _fold_scientific_axis_label(ax, axis="y", label="Density")
 
 
 def _draw_empty_norm_figure(fig: Figure, title: str, message: str) -> None:


### PR DESCRIPTION
## Summary

- Change batch figure export defaults to produce 300 dpi PNG only.
- Add `output.save_pdf` as an explicit opt-in for PDF companion files.
- Register `save_pdf` in shared config defaults and `OutputConfig` normalization.
- Fold `01_QC_and_Preprocessing/normalization_comparison.png` scientific scale factors into axis labels instead of leaving floating Matplotlib offset text.
- Use visible axis ranges when choosing normalization comparison scale labels, so the before-normalization boxplot can label as `Intensity ($\times 10^{8}$)` even when density/outlier ranges extend to `10^9`.
- Apply the same offset folding to before-density x/y axes, for example `Intensity ($\times 10^{9}$)` and `Density ($\times 10^{-9}$)`.
- Update publication export and batch smoke tests for the new output contracts.

## Why

Batch report folders were getting noisy because every figure emitted both PNG and PDF by default. The desired default is still publication-quality PNG, while PDF export should remain available when explicitly requested.

The normalization comparison preview also had a publication-readability issue: Matplotlib's default scientific offset text can land in an awkward corner and is easy to miss. Moving the scale into each affected axis label matches the intended figure style while keeping ANOVA feature boxplots on their transformed-data labeling.

## Validation

- `uv run pytest tests\test_publication_export_v2.py::TestNormalizationComparisonAxes::test_group_boxplot_scientific_scale_is_folded_into_ylabel -v`
- `uv run pytest tests\test_app_config.py tests\test_publication_export_v2.py tests\test_publication_batch_report_smoke.py::test_publication_report_smoke_layout_and_pruning -v`
- `python -m py_compile core\app_config.py core\param_specs.py scripts\run_from_config.py visualization\norm_preview.py tests\test_app_config.py tests\test_publication_export_v2.py tests\test_publication_batch_report_smoke.py`
- Manual batch run using `C:\Users\user\Desktop\NTU cancer\Processed Data\DNA\Mzmine\new_test\run_20260406_025159\Step4_Normalized_PQN.xlsx` and `configs\Tissue_knn_rsd050_marker_verify.yaml`
- Latest manual output: `results\Step4_Normalized_PQN_tissue_knn_rsd050_marker_verify_20260413_150247`

## Notes

Set `output.save_pdf: true` in a config to re-enable PDF figure companions.