### PR TITLE
[codex] Consume Step4 metadata and improve review reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,180 @@
+# MetaboAnalyst Clone
+
+Desktop and CLI metabolomics analysis workflow inspired by MetaboAnalyst, with a focus on transparent preprocessing, marker-aware imputation, statistical reporting, and publication-oriented exports.
+
+## Current Status
+
+The current implementation includes the MA consumer for DNP Step4 feature metadata and the current CLI report workflow:
+
+- Step4 feature metadata is parsed and preserved instead of being mistaken for sample columns.
+- `is_Presence_Absence_Marker` is the only routing field for marker-aware imputation.
+- Presence/absence marker features use min positive / 5 imputation; other features use the configured method, for example KNN.
+- `Feature_Filter_Keep_Reasons` and `Imputation_Tag_Reasons` are retained as feature metadata and exported for audit.
+- ComBat is available as an optional batch-correction method using `SampleInfo.Batch`, with label-preserving or SampleInfo covariate modes.
+- CLI outputs are organized into a publication-oriented folder layout with `Summary.csv`, `significant_features_summary.xlsx`, and a curated `00_Review_Pack`.
+
+## Quick Start
+
+Run the pipeline with an input workbook and YAML config:
+
+```powershell
+run.cmd "C:\path\to\Step3_Normalized_SpecNorm_PQN.xlsx" "configs\Tissue_knn_rsd050_marker_verify.yaml"
+```
+
+Equivalent explicit wrapper:
+
+```powershell
+scripts\run_pipeline.cmd -Config "configs\Tissue_knn_rsd050_marker_verify.yaml" -Input "C:\path\to\Step3_Normalized_SpecNorm_PQN.xlsx"
+```
+
+Direct Python entry point:
+
+```powershell
+uv run python scripts\run_from_config.py configs\Tissue_knn_rsd050_marker_verify.yaml --input "C:\path\to\Step3_Normalized_SpecNorm_PQN.xlsx"
+```
+
+Outputs are written under `results\<input-stem><output.suffix>_<timestamp>\`.
+
+## Input Contract
+
+The recommended Excel input is a feature matrix with samples as columns and features as rows. If the workbook contains a `SampleInfo` sheet, MA uses it for group labels, pairing, concentration factors, and ComBat batch metadata where configured.
+
+DNP Step4 metadata columns are treated as feature metadata, not sample columns:
+
+- `is_Presence_Absence_Marker`
+- `Feature_Filter_Keep_Reasons`
+- `Imputation_Tag_Reasons`
+- `Feature_Filter_Delete_Reasons`
+- `Detection_Profile`
+- `*_ratio`, including `QC_ratio`
+
+If any Step4 metadata column is detected, `is_Presence_Absence_Marker` is required. Legacy MA inputs without Step4 metadata remain supported and default all marker flags to `False`.
+
+## Imputation And Feature Metadata
+
+The imputation router uses only `is_Presence_Absence_Marker`:
+
+| Marker value | Imputation route |
+|---|---|
+| `True` | min positive / 5 |
+| `False` | configured method, for example `pipeline.impute_method: "knn"` |
+
+Reason and ratio fields are audit metadata only. They are not used to infer marker status.
+
+`feature_metadata.csv` keeps the final feature metadata after preprocessing. Downstream result tables and workbook sheets preserve relevant Step4 metadata so the statistical results can be traced back to DNP Step4 decisions.
+
+## ComBat Batch Correction
+
+ComBat is opt-in through config:
+
+```yaml
+pipeline:
+  batch_correction: "ComBat"
+
+combat:
+  covariate_mode: "labels"          # or "sample_info"
+  sample_info_covariates: []        # required when covariate_mode is "sample_info"
+  mean_only: false
+  par_prior: true
+  ref_batch: null
+```
+
+Current behavior:
+
+- Batch labels come from `SampleInfo.Batch`.
+- `covariate_mode: "labels"` preserves the current biological sample labels.
+- `covariate_mode: "sample_info"` preserves selected SampleInfo covariates, such as `Sex`.
+- The design is validated before running. Perfect or unsafe batch-label confounding blocks ComBat; strong overlap emits warnings in CLI and GUI.
+- Missing-value imputation runs before ComBat.
+
+## CLI Report Output
+
+The CLI report is organized by analysis purpose:
+
+```text
+<output_dir>\
+  00_Review_Pack\
+  01_QC_and_Preprocessing\
+  02_Global_Profiling\
+  03_Feature_Selection\
+  04_Biomarker_Validation\
+  05_Supplementary\
+  Summary.csv
+  significant_features_summary.xlsx
+```
+
+Key folders:
+
+- `00_Review_Pack`: curated PNG-only quick review pack.
+- `01_QC_and_Preprocessing`: processed data, sample labels, feature metadata, config copy, normalization comparison, PCA score plot.
+- `02_Global_Profiling`: clustered `heatmap_top50.png` and grouped `heatmap_top50_grouped.png`.
+- `03_Feature_Selection`: ANOVA, VIP, Volcano, OPLS-DA figures and CSV outputs.
+- `04_Biomarker_Validation`: ROC and AUC ranking outputs.
+- `05_Supplementary`: all-groups PLS-DA, outlier plots, Random Forest plots, ANOVA feature boxplots, paired-resolution audit.
+
+When `pipeline.qc_rsd_enabled: false`, QC-RSD audit columns and `qc_rsd_audit.csv` are not emitted as fake disabled placeholders.
+
+## Review Pack
+
+`00_Review_Pack` contains the high-signal PNGs intended for fast review:
+
+- PCA score plot
+- grouped heatmap top 50
+- ANOVA importance
+- PLS-DA all-groups score plot
+- for each configured comparison pair: OPLS-DA score, PLS-DA VIP, Volcano
+
+The grouped heatmap is the Review Pack heatmap because it is easier to read by biological group. The clustered heatmap remains in `02_Global_Profiling` as a diagnostic view.
+
+## Summary And Evidence Tier
+
+`Summary.csv` and the `Summary` sheet in `significant_features_summary.xlsx` summarize feature-level evidence across ANOVA, VIP, and Volcano results.
+
+`Evidence_Tier` is feature-level statistical evidence, not Step4 metadata:
+
+| Tier | Meaning |
+|---|---|
+| `Tier1_ConcordantPairwise` | Same comparison pair is supported by VIP and Volcano top-15 evidence, or by VIP + Volcano plus ANOVA significance |
+| `Tier2_MultiMethod` | At least two evidence families pass among ANOVA, VIP, and Volcano |
+| `Tier3_SingleMethod` | Exactly one evidence family passes |
+| `Tier0_NoStatEvidence` | No summary-eligible statistical evidence passes |
+
+In `significant_features_summary.xlsx`, `Evidence_Tier` is color-coded:
+
+- Tier1: green
+- Tier2: blue
+- Tier3: yellow
+- Tier0: gray
+
+Step4 detail columns such as reason and ratio metadata are preserved in the workbook and are collapsed by default in Excel. Use Excel's outline controls to expand them.
+
+## Built-In Presets
+
+GUI built-in presets live in `resources\presets\` and are whitelisted by `resources\presets\manifest.yaml`.
+
+CLI configs live in `configs\`. Some configs are historical or validation profiles and are not automatically exposed as GUI presets.
+
+Use `configs\Tissue_knn_rsd050_marker_verify.yaml` as the tracked tissue marker-verification CLI profile. For workflows where QC-RSD should be disabled because QC samples are not truly shared across batches, use or create a config with:
+
+```yaml
+pipeline:
+  qc_rsd_enabled: false
+```
+
+## Development
+
+Install dependencies:
+
+```powershell
+uv pip install -r requirements.txt
+```
+
+Run targeted tests:
+
+```powershell
+uv run pytest tests\test_run_from_config_input_formats.py -q
+uv run pytest tests\test_publication_batch_report_smoke.py -q
+uv run pytest tests\test_grouped_heatmap.py -q
+```
+
+See `AGENT.md` and `claude.md` for development workflow, architecture rules, and CI/test strategy.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,73 @@
 # MetaboAnalyst Clone
 
-Desktop and CLI metabolomics analysis workflow inspired by MetaboAnalyst, with a focus on transparent preprocessing, marker-aware imputation, statistical reporting, and publication-oriented exports.
+Desktop and CLI workflow for LC-MS metabolomics analysis. The project is
+inspired by MetaboAnalyst-style analysis, but is implemented as a local,
+auditable Python pipeline with explicit Excel input contracts, marker-aware
+imputation, optional ComBat batch correction, and publication-oriented report
+exports.
 
-## Current Status
+## What It Does
 
-The current implementation includes the MA consumer for DNP Step4 feature metadata and the current CLI report workflow:
+MetaboAnalyst Clone is designed for normalized feature matrices produced by an
+upstream preprocessing workflow such as DNP. It consumes a feature matrix,
+optional `SampleInfo`, and optional DNP Step4 feature metadata, then produces
+statistical tables, diagnostic plots, curated review figures, and an annotated
+summary workbook.
 
-- Step4 feature metadata is parsed and preserved instead of being mistaken for sample columns.
-- `is_Presence_Absence_Marker` is the only routing field for marker-aware imputation.
-- Presence/absence marker features use min positive / 5 imputation; other features use the configured method, for example KNN.
-- `Feature_Filter_Keep_Reasons` and `Imputation_Tag_Reasons` are retained as feature metadata and exported for audit.
-- ComBat is available as an optional batch-correction method using `SampleInfo.Batch`, with label-preserving or SampleInfo covariate modes.
-- CLI outputs are organized into a publication-oriented folder layout with `Summary.csv`, `significant_features_summary.xlsx`, and a curated `00_Review_Pack`.
+Current highlights:
+
+- GUI and CLI execution paths share the same core pipeline.
+- Excel inputs can include a `SampleInfo` sheet for group labels, pairing,
+  concentration factors, and batch metadata.
+- DNP Step4 metadata is recognized as feature metadata, not sample columns.
+- `is_Presence_Absence_Marker` is the only routing authority for marker-aware
+  imputation.
+- Presence/absence marker features use min positive / 5 imputation; non-marker
+  features use the configured imputation method, for example KNN.
+- Optional ComBat correction runs after imputation and uses `SampleInfo.Batch`.
+- CLI exports include `Summary.csv`, `significant_features_summary.xlsx`, and a
+  curated PNG-only `00_Review_Pack`.
+- `Evidence_Tier` summarizes cross-method statistical support across ANOVA,
+  VIP, and Volcano evidence.
+
+## Table Of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Input Workbook Contract](#input-workbook-contract)
+- [Pipeline Overview](#pipeline-overview)
+- [Configuration](#configuration)
+- [Report Outputs](#report-outputs)
+- [Review Pack](#review-pack)
+- [Summary And Evidence Tier](#summary-and-evidence-tier)
+- [GUI Workflow](#gui-workflow)
+- [Project Layout](#project-layout)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [License](#license)
+
+## Installation
+
+Recommended Windows / PowerShell setup:
+
+```powershell
+uv venv
+uv pip install -r requirements.txt
+```
+
+If you already have a compatible environment, install the dependencies directly:
+
+```powershell
+python -m pip install -r requirements.txt
+```
+
+Core runtime dependencies include `numpy`, `pandas`, `scipy`,
+`scikit-learn`, `statsmodels`, `matplotlib`, `seaborn`, `openpyxl`,
+`PySide6`, `pyyaml`, `plotly`, `qnorm`, `fancyimpute`, and `inmoose`.
 
 ## Quick Start
 
-Run the pipeline with an input workbook and YAML config:
+Run the CLI pipeline with an input workbook and YAML config:
 
 ```powershell
 run.cmd "C:\path\to\Step3_Normalized_SpecNorm_PQN.xlsx" "configs\Tissue_knn_rsd050_marker_verify.yaml"
@@ -33,46 +85,132 @@ Direct Python entry point:
 uv run python scripts\run_from_config.py configs\Tissue_knn_rsd050_marker_verify.yaml --input "C:\path\to\Step3_Normalized_SpecNorm_PQN.xlsx"
 ```
 
-Outputs are written under `results\<input-stem><output.suffix>_<timestamp>\`.
+Launch the desktop GUI:
 
-## Input Contract
+```powershell
+uv run python main.py
+```
 
-The recommended Excel input is a feature matrix with samples as columns and features as rows. If the workbook contains a `SampleInfo` sheet, MA uses it for group labels, pairing, concentration factors, and ComBat batch metadata where configured.
+CLI outputs are written under:
 
-DNP Step4 metadata columns are treated as feature metadata, not sample columns:
+```text
+results\<input-stem><output.suffix>_<timestamp>\
+```
 
-- `is_Presence_Absence_Marker`
-- `Feature_Filter_Keep_Reasons`
-- `Imputation_Tag_Reasons`
-- `Feature_Filter_Delete_Reasons`
-- `Detection_Profile`
-- `*_ratio`, including `QC_ratio`
+The suffix comes from `output.suffix` in the selected YAML config. Keep config
+names and suffixes semantically aligned with the enabled options, for example
+avoid an `_rsd050` suffix when QC-RSD filtering is disabled.
 
-If any Step4 metadata column is detected, `is_Presence_Absence_Marker` is required. Legacy MA inputs without Step4 metadata remain supported and default all marker flags to `False`.
+## Input Workbook Contract
 
-## Imputation And Feature Metadata
+The recommended input is an Excel workbook with:
 
-The imputation router uses only `is_Presence_Absence_Marker`:
+- A feature matrix sheet with features as rows and samples as columns.
+- A feature identifier column that can be used as the row index.
+- Optional `SampleInfo` sheet with sample-level metadata.
+
+`SampleInfo` is used for:
+
+- group labels and GUI/CLI sample alignment;
+- paired analysis identifiers;
+- concentration metadata where configured;
+- batch labels for ComBat through `SampleInfo.Batch`;
+- future covariates such as sex or other study design variables.
+
+### DNP Step4 Feature Metadata
+
+DNP Step4 metadata columns are preserved as feature metadata and excluded from
+the analysis matrix:
+
+| Column pattern | Behavior |
+|---|---|
+| `is_Presence_Absence_Marker` | Required routing field when any Step4 metadata is present |
+| `Feature_Filter_Keep_Reasons` | Optional audit metadata |
+| `Imputation_Tag_Reasons` | Optional audit metadata |
+| `Feature_Filter_Delete_Reasons` | Optional audit metadata if present in the main matrix |
+| `Detection_Profile` | Optional audit metadata |
+| `*_ratio`, `QC_ratio` | Parsed as numeric feature metadata and excluded from samples |
+
+If any Step4 metadata column is detected, `is_Presence_Absence_Marker` must be
+present and must use a supported boolean encoding. Legacy MA inputs with no
+Step4 metadata remain supported and default all marker flags to `False`.
+
+Supported marker encodings:
+
+| True | False |
+|---|---|
+| `True`, `TRUE`, `true`, `1`, `1.0` | `False`, `FALSE`, `false`, `0`, `0.0` |
+
+Blank or unknown marker values are validation errors because they would make
+imputation routing ambiguous.
+
+## Pipeline Overview
+
+The CLI and GUI use the same high-level processing sequence:
+
+1. Load the Excel matrix and optional `SampleInfo`.
+2. Detect sample columns while excluding known feature metadata.
+3. Convert zero-like missing values where configured.
+4. Remove features by missingness threshold.
+5. Apply marker-aware imputation.
+6. Apply optional QC-RSD filtering when enabled.
+7. Apply row normalization, transformation, optional ComBat, and scaling.
+8. Run global profiling and statistical analyses.
+9. Export annotated tables, plots, summary workbooks, and review figures.
+
+Imputation routing is intentionally simple:
 
 | Marker value | Imputation route |
 |---|---|
 | `True` | min positive / 5 |
 | `False` | configured method, for example `pipeline.impute_method: "knn"` |
 
-Reason and ratio fields are audit metadata only. They are not used to infer marker status.
+Reason and ratio metadata are not used to infer marker status.
 
-`feature_metadata.csv` keeps the final feature metadata after preprocessing. Downstream result tables and workbook sheets preserve relevant Step4 metadata so the statistical results can be traced back to DNP Step4 decisions.
+## Configuration
 
-## ComBat Batch Correction
+CLI configs live in `configs\`. GUI built-in presets live in
+`resources\presets\` and are whitelisted by `resources\presets\manifest.yaml`.
+Not every CLI config is exposed as a GUI preset.
 
-ComBat is opt-in through config:
+Use the tracked tissue marker-verification profile as a starting point:
+
+```powershell
+configs\Tissue_knn_rsd050_marker_verify.yaml
+```
+
+Common pipeline keys:
+
+```yaml
+pipeline:
+  missing_thresh: 1.0
+  impute_method: "knn"
+  qc_rsd_enabled: true
+  qc_rsd_threshold: 0.50
+  row_norm: "None"
+  transform: "Log10Norm"
+  batch_correction: "None"
+  scaling: "ParetoNorm"
+```
+
+When QC samples are not truly shared across batches, prefer disabling QC-RSD
+filtering rather than emitting disabled placeholder columns:
+
+```yaml
+pipeline:
+  qc_rsd_enabled: false
+```
+
+### ComBat
+
+ComBat is opt-in and runs after missing-value imputation:
 
 ```yaml
 pipeline:
   batch_correction: "ComBat"
 
 combat:
-  covariate_mode: "labels"          # or "sample_info"
+  covariate_mode: "labels"          # "labels", "sample_info", or "none"
   sample_info_covariates: []        # required when covariate_mode is "sample_info"
   mean_only: false
   par_prior: true
@@ -82,12 +220,14 @@ combat:
 Current behavior:
 
 - Batch labels come from `SampleInfo.Batch`.
-- `covariate_mode: "labels"` preserves the current biological sample labels.
-- `covariate_mode: "sample_info"` preserves selected SampleInfo covariates, such as `Sex`.
-- The design is validated before running. Perfect or unsafe batch-label confounding blocks ComBat; strong overlap emits warnings in CLI and GUI.
-- Missing-value imputation runs before ComBat.
+- `covariate_mode: "labels"` preserves the configured biological labels.
+- `covariate_mode: "sample_info"` preserves selected `SampleInfo` covariates.
+- `covariate_mode: "none"` performs batch-only correction.
+- Perfect or unsafe batch-label confounding blocks ComBat.
+- Strong batch-label overlap emits warnings in both CLI and GUI.
+- Single-batch data should leave ComBat disabled.
 
-## CLI Report Output
+## Report Outputs
 
 The CLI report is organized by analysis purpose:
 
@@ -103,34 +243,50 @@ The CLI report is organized by analysis purpose:
   significant_features_summary.xlsx
 ```
 
-Key folders:
+| Output | Purpose |
+|---|---|
+| `Summary.csv` | Feature-level evidence summary for quick filtering and review |
+| `significant_features_summary.xlsx` | Annotated workbook with summary and method-specific sheets |
+| `feature_metadata.csv` | Final feature metadata after preprocessing |
+| `00_Review_Pack\` | Curated PNG-only review set |
+| `01_QC_and_Preprocessing\` | Processed data, labels, config copy, PCA, normalization comparison |
+| `02_Global_Profiling\` | Clustered heatmap and grouped heatmap |
+| `03_Feature_Selection\` | ANOVA, VIP, Volcano, OPLS-DA figures and CSV outputs |
+| `04_Biomarker_Validation\` | ROC and AUC ranking outputs |
+| `05_Supplementary\` | PLS-DA all-groups, outlier plots, Random Forest, boxplots, paired audit |
 
-- `00_Review_Pack`: curated PNG-only quick review pack.
-- `01_QC_and_Preprocessing`: processed data, sample labels, feature metadata, config copy, normalization comparison, PCA score plot.
-- `02_Global_Profiling`: clustered `heatmap_top50.png` and grouped `heatmap_top50_grouped.png`.
-- `03_Feature_Selection`: ANOVA, VIP, Volcano, OPLS-DA figures and CSV outputs.
-- `04_Biomarker_Validation`: ROC and AUC ranking outputs.
-- `05_Supplementary`: all-groups PLS-DA, outlier plots, Random Forest plots, ANOVA feature boxplots, paired-resolution audit.
-
-When `pipeline.qc_rsd_enabled: false`, QC-RSD audit columns and `qc_rsd_audit.csv` are not emitted as fake disabled placeholders.
+When `pipeline.qc_rsd_enabled: false`, QC-RSD audit columns and
+`qc_rsd_audit.csv` are not emitted as fake disabled placeholders.
 
 ## Review Pack
 
-`00_Review_Pack` contains the high-signal PNGs intended for fast review:
+`00_Review_Pack` contains high-signal PNGs intended for first-pass review:
 
-- PCA score plot
-- grouped heatmap top 50
-- ANOVA importance
-- PLS-DA all-groups score plot
-- for each configured comparison pair: OPLS-DA score, PLS-DA VIP, Volcano
+- PCA score plot.
+- Grouped heatmap top 50.
+- ANOVA importance.
+- PLS-DA all-groups score plot.
+- For each configured comparison pair: OPLS-DA score, PLS-DA VIP, and Volcano.
 
-The grouped heatmap is the Review Pack heatmap because it is easier to read by biological group. The clustered heatmap remains in `02_Global_Profiling` as a diagnostic view.
+The grouped heatmap is optimized for biological group readability:
+
+- samples are ordered by `groups.include`;
+- unknown groups are placed last;
+- group-internal sample order follows the input matrix;
+- group labels are shown in the left strip;
+- feature order follows ANOVA ranking and is not column-clustered.
+
+The original clustered `heatmap_top50.png` remains in `02_Global_Profiling` as
+a diagnostic clustering view.
 
 ## Summary And Evidence Tier
 
-`Summary.csv` and the `Summary` sheet in `significant_features_summary.xlsx` summarize feature-level evidence across ANOVA, VIP, and Volcano results.
+`Summary.csv` and the `Summary` sheet in
+`significant_features_summary.xlsx` summarize feature-level evidence across
+ANOVA, VIP, and Volcano results.
 
-`Evidence_Tier` is feature-level statistical evidence, not Step4 metadata:
+`Evidence_Tier` is statistical evidence only. It is not derived from DNP Step4
+reason or ratio metadata.
 
 | Tier | Meaning |
 |---|---|
@@ -139,42 +295,102 @@ The grouped heatmap is the Review Pack heatmap because it is easier to read by b
 | `Tier3_SingleMethod` | Exactly one evidence family passes |
 | `Tier0_NoStatEvidence` | No summary-eligible statistical evidence passes |
 
+Evidence family thresholds:
+
+| Family | Rule |
+|---|---|
+| ANOVA | `pvalue_adj < 0.05` |
+| VIP | `VIP > 1.0` |
+| Volcano | `pvalue_adj < 0.05` and `abs(log2FC) >= 1.0` |
+
 In `significant_features_summary.xlsx`, `Evidence_Tier` is color-coded:
 
-- Tier1: green
-- Tier2: blue
-- Tier3: yellow
-- Tier0: gray
+| Tier | Color |
+|---|---|
+| Tier1 | green |
+| Tier2 | blue |
+| Tier3 | yellow |
+| Tier0 | gray |
 
-Step4 detail columns such as reason and ratio metadata are preserved in the workbook and are collapsed by default in Excel. Use Excel's outline controls to expand them.
+Step4 detail columns such as reason and ratio metadata are preserved in the
+workbook and collapsed by default in Excel. Use Excel outline controls to
+expand them when audit details are needed.
 
-## Built-In Presets
+## GUI Workflow
 
-GUI built-in presets live in `resources\presets\` and are whitelisted by `resources\presets\manifest.yaml`.
-
-CLI configs live in `configs\`. Some configs are historical or validation profiles and are not automatically exposed as GUI presets.
-
-Use `configs\Tissue_knn_rsd050_marker_verify.yaml` as the tracked tissue marker-verification CLI profile. For workflows where QC-RSD should be disabled because QC samples are not truly shared across batches, use or create a config with:
-
-```yaml
-pipeline:
-  qc_rsd_enabled: false
-```
-
-## Development
-
-Install dependencies:
+Start the GUI with:
 
 ```powershell
-uv pip install -r requirements.txt
+uv run python main.py
 ```
 
-Run targeted tests:
+The GUI supports:
+
+- workbook import and sample alignment;
+- Step4 metadata detection summary;
+- presence/absence marker count;
+- ratio and reason metadata validation;
+- shared config/preset behavior with the CLI;
+- ComBat controls and validation warnings;
+- report generation through the same pipeline backend.
+
+GUI import does not add new Step4 settings. It validates, summarizes, and
+passes feature metadata into the shared pipeline.
+
+## Project Layout
+
+```text
+analysis\        Statistical analysis modules
+configs\         CLI YAML profiles
+core\            Shared data loading, metadata, preprocessing, and validation
+docs\            Specs, plans, testing notes, and implementation records
+gui\             PySide6 desktop interface
+resources\       GUI resources and built-in presets
+scripts\         CLI entry points and utility scripts
+tests\           Pytest regression and smoke coverage
+translations\    i18n resources
+visualization\   Plotting and report figure generation
+```
+
+## Testing
+
+Run focused tests for the current metadata/report workflow:
 
 ```powershell
 uv run pytest tests\test_run_from_config_input_formats.py -q
-uv run pytest tests\test_publication_batch_report_smoke.py -q
 uv run pytest tests\test_grouped_heatmap.py -q
+uv run pytest tests\test_publication_batch_report_smoke.py -q
 ```
 
-See `AGENT.md` and `claude.md` for development workflow, architecture rules, and CI/test strategy.
+Useful additional checks:
+
+```powershell
+uv run pytest -m "gui and not slow" -q
+uv run pytest tests\test_publication_export_v2.py -q
+python -m py_compile scripts\run_from_config.py visualization\heatmap.py visualization\__init__.py
+```
+
+For broader testing strategy, see `docs\testing\pytest-guidelines.md` and
+`docs\testing\full-suite-strategy.md`.
+
+## Documentation
+
+Important project docs:
+
+- `docs\specs\01-algorithms.md`
+- `docs\specs\02-visualization.md`
+- `docs\specs\03-gui.md`
+- `docs\specs\06-compatibility.md`
+- `docs\plans\2026-04-11-publication-batch-report-v1.md`
+- `docs\plans\2026-04-24-ma-combat-preset-ui-validation-design.md`
+- `resources\presets\README.md`
+- `claude.md`
+
+The root README is intended to stay concise enough for first-time users. Keep
+long design notes, implementation plans, and test strategy details under
+`docs\`.
+
+## License
+
+No repository license file is currently included. Add an explicit license file
+before public redistribution or external reuse.

--- a/core/feature_metadata.py
+++ b/core/feature_metadata.py
@@ -2,10 +2,65 @@
 
 from __future__ import annotations
 
+import re
+
 import pandas as pd
 
 FEATURE_MARKER_COLUMN = "is_Presence_Absence_Marker"
-_TRUTHY_MARKER_VALUES = frozenset({"true", "1", "yes", "y"})
+FEATURE_KEEP_REASONS_COLUMN = "Feature_Filter_Keep_Reasons"
+IMPUTATION_TAG_REASONS_COLUMN = "Imputation_Tag_Reasons"
+FEATURE_DELETE_REASONS_COLUMN = "Feature_Filter_Delete_Reasons"
+DETECTION_PROFILE_COLUMN = "Detection_Profile"
+
+STEP4_STATIC_METADATA_COLUMNS = (
+    FEATURE_MARKER_COLUMN,
+    FEATURE_KEEP_REASONS_COLUMN,
+    IMPUTATION_TAG_REASONS_COLUMN,
+    FEATURE_DELETE_REASONS_COLUMN,
+    DETECTION_PROFILE_COLUMN,
+)
+STEP4_REASON_COLUMNS = (
+    FEATURE_KEEP_REASONS_COLUMN,
+    IMPUTATION_TAG_REASONS_COLUMN,
+)
+
+_TRUTHY_MARKER_VALUES = frozenset({"true", "1", "1.0"})
+_FALSY_MARKER_VALUES = frozenset({"false", "0", "0.0"})
+
+
+def _normalize_column_name(value: object) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value).strip().lower())
+
+
+_STATIC_METADATA_BY_NORMALIZED_NAME = {
+    _normalize_column_name(column): column for column in STEP4_STATIC_METADATA_COLUMNS
+}
+
+
+def is_step4_ratio_column(column_name: object) -> bool:
+    """Return True for Step4 dynamic ratio metadata columns."""
+    text = str(column_name).strip().lower()
+    return text == "qc_ratio" or text.endswith("_ratio")
+
+
+def is_step4_feature_metadata_column(column_name: object) -> bool:
+    """Return True when a column is Step4 feature-level metadata."""
+    normalized = _normalize_column_name(column_name)
+    return normalized in _STATIC_METADATA_BY_NORMALIZED_NAME or is_step4_ratio_column(column_name)
+
+
+def canonical_step4_metadata_column(column_name: object) -> str:
+    """Return the canonical name for static Step4 metadata columns."""
+    normalized = _normalize_column_name(column_name)
+    return _STATIC_METADATA_BY_NORMALIZED_NAME.get(normalized, str(column_name))
+
+
+def _find_column(columns: pd.Index, target: str) -> str | None:
+    target_normalized = _normalize_column_name(target)
+    for column in columns:
+        if _normalize_column_name(column) == target_normalized:
+            return str(column)
+    return None
 
 
 def default_feature_metadata(feature_names: pd.Index) -> pd.DataFrame:
@@ -13,6 +68,7 @@ def default_feature_metadata(feature_names: pd.Index) -> pd.DataFrame:
     index = pd.Index(feature_names.copy(), name="Feature")
     metadata = pd.DataFrame(index=index)
     metadata[FEATURE_MARKER_COLUMN] = False
+    metadata.attrs["step4_metadata_detected"] = False
     return metadata
 
 
@@ -21,25 +77,76 @@ def normalize_presence_absence_marker(
     feature_names: pd.Index,
 ) -> pd.Series:
     """Normalize marker annotations to a strict boolean series."""
-    normalized = pd.Series(False, index=feature_names, dtype=bool)
+    normalized_values: list[bool] = []
+    invalid_values: list[str] = []
     for feature_name, value in zip(feature_names, values, strict=False):
         if pd.isna(value):
+            invalid_values.append(f"{feature_name}=<blank>")
             continue
         text = str(value).strip().lower()
+        if not text:
+            invalid_values.append(f"{feature_name}=<blank>")
+            continue
         if text in _TRUTHY_MARKER_VALUES:
-            normalized.loc[feature_name] = True
-    return normalized
+            normalized_values.append(True)
+        elif text in _FALSY_MARKER_VALUES:
+            normalized_values.append(False)
+        else:
+            invalid_values.append(f"{feature_name}={value!r}")
+
+    if invalid_values:
+        preview = ", ".join(invalid_values[:5])
+        extra = "" if len(invalid_values) <= 5 else f" (+{len(invalid_values) - 5} more)"
+        raise ValueError(
+            f"Invalid {FEATURE_MARKER_COLUMN} values: {preview}{extra}. "
+            "Expected True/TRUE/true/1/1.0 or False/FALSE/false/0/0.0."
+        )
+
+    return pd.Series(normalized_values, index=feature_names, dtype=bool)
 
 
 def extract_feature_metadata(raw_feature_rows: pd.DataFrame, feature_names: pd.Index) -> pd.DataFrame:
     """Extract shared feature metadata from feature rows only."""
     metadata = default_feature_metadata(feature_names)
-    if FEATURE_MARKER_COLUMN not in raw_feature_rows.columns:
+    step4_columns = [
+        str(column)
+        for column in raw_feature_rows.columns
+        if is_step4_feature_metadata_column(column)
+    ]
+    if not step4_columns:
         return metadata
 
-    marker_values = raw_feature_rows[FEATURE_MARKER_COLUMN].reset_index(drop=True)
+    marker_column = _find_column(raw_feature_rows.columns, FEATURE_MARKER_COLUMN)
+    if marker_column is None:
+        raise ValueError(
+            "Step4 feature metadata columns were detected "
+            f"({', '.join(step4_columns[:5])}), but required column "
+            f"{FEATURE_MARKER_COLUMN} is missing."
+        )
+
+    metadata.attrs["step4_metadata_detected"] = True
+    marker_values = raw_feature_rows[marker_column].reset_index(drop=True)
     metadata[FEATURE_MARKER_COLUMN] = normalize_presence_absence_marker(
         marker_values,
         metadata.index,
     )
+    for column in raw_feature_rows.columns:
+        column_name = str(column)
+        if column_name == marker_column or not is_step4_feature_metadata_column(column_name):
+            continue
+
+        output_column = canonical_step4_metadata_column(column_name)
+        values = raw_feature_rows[column].reset_index(drop=True)
+        if is_step4_ratio_column(column_name):
+            try:
+                metadata[output_column] = (
+                    pd.to_numeric(values, errors="raise").astype(float).to_numpy()
+                )
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid numeric Step4 ratio metadata in column '{column_name}'."
+                ) from exc
+        else:
+            blank_mask = values.astype("string").str.strip().eq("").fillna(False)
+            metadata[output_column] = values.mask(blank_mask, other=float("nan")).to_numpy()
     return metadata

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -195,14 +195,6 @@ class MetaboAnalystPipeline:
                 feature_metadata["kept_after_qc_rsd"] = True
                 self.step_feature_metadata["qc_rsd"] = feature_metadata.copy()
                 self.log.append("Step 3a: QC-RSD enabled but no QC samples detected")
-        else:
-            feature_metadata["qc_rsd"] = pd.NA
-            feature_metadata["qc_rsd_threshold"] = pd.NA
-            feature_metadata["qc_detect_ratio"] = pd.NA
-            feature_metadata["qc_rsd_pass"] = False
-            feature_metadata["qc_rsd_exempted"] = False
-            feature_metadata["kept_after_qc_rsd"] = True
-            self.step_feature_metadata["qc_rsd"] = feature_metadata.copy()
 
         # Step 3b: variable filtering
         if filter_method in (None, "None"):

--- a/core/sample_interface.py
+++ b/core/sample_interface.py
@@ -5,6 +5,8 @@ import re
 
 import pandas as pd
 
+from core.feature_metadata import is_step4_feature_metadata_column
+
 
 REQUIRED_SAMPLE_INFO_COLUMNS = ("Sample_Name", "Sample_Type", "Batch")
 
@@ -52,6 +54,8 @@ def _normalize_column_name(value) -> str:
 
 
 def _is_non_sample_column(column_name: str) -> bool:
+    if is_step4_feature_metadata_column(column_name):
+        return True
     normalized = _normalize_column_name(column_name)
     if normalized in NON_SAMPLE_COLUMN_PATTERNS:
         return True

--- a/gui/data_import_tab.py
+++ b/gui/data_import_tab.py
@@ -34,7 +34,13 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from core.feature_metadata import default_feature_metadata, extract_feature_metadata
+from core.feature_metadata import (
+    FEATURE_MARKER_COLUMN,
+    STEP4_REASON_COLUMNS,
+    default_feature_metadata,
+    extract_feature_metadata,
+    is_step4_ratio_column,
+)
 from core.input_resolver import (
     build_labels_from_sample_info,
     detect_sample_type_row_key,
@@ -577,11 +583,12 @@ class DataImportTab(QWidget):
             self.tr(
                 "Dataset loaded into pipeline.\n"
                 "Samples: {samples}\nFeatures: {features}\n"
-                "Groups: {groups}"
+                "Groups: {groups}{metadata_summary}"
             ).format(
                 samples=matrix.shape[0],
                 features=matrix.shape[1],
                 groups=", ".join(sorted(set(labels.astype(str)))),
+                metadata_summary=self._format_step4_metadata_summary(feature_metadata),
             )
         )
         if announce_success:
@@ -715,3 +722,31 @@ class DataImportTab(QWidget):
             counts[key] = n + 1
             output.append(key if n == 0 else f"{key}_{n+1}")
         return output
+
+    @staticmethod
+    def _format_step4_metadata_summary(feature_metadata: pd.DataFrame) -> str:
+        if not feature_metadata.attrs.get("step4_metadata_detected", False):
+            return ""
+
+        marker_count = int(feature_metadata[FEATURE_MARKER_COLUMN].sum())
+        ratio_columns = [
+            str(column)
+            for column in feature_metadata.columns
+            if is_step4_ratio_column(column)
+        ]
+        present_reasons = [
+            column for column in STEP4_REASON_COLUMNS if column in feature_metadata.columns
+        ]
+        missing_reasons = [
+            column for column in STEP4_REASON_COLUMNS if column not in feature_metadata.columns
+        ]
+        present_text = ", ".join(present_reasons) if present_reasons else "none"
+        missing_text = ", ".join(missing_reasons) if missing_reasons else "none"
+        ratio_text = ", ".join(ratio_columns) if ratio_columns else "none"
+        return (
+            "\nStep4 metadata detected"
+            f"\nPresence/absence markers: {marker_count}"
+            f"\nRatio columns: {len(ratio_columns)} ({ratio_text})"
+            f"\nReason columns present: {present_text}"
+            f"\nReason columns missing: {missing_text}"
+        )

--- a/resources/presets/README.md
+++ b/resources/presets/README.md
@@ -6,4 +6,6 @@ This directory contains GUI built-in presets that are safe to expose in the prod
 - Files in `configs/` may still exist for CLI or historical workflows, but they are not treated as GUI built-in presets.
 - User-saved local presets belong in the application data directory returned by `get_app_data_dir()/presets`.
 - Built-in and seed presets should explicitly list every visible normalization-stage key: `row_norm`, `transform`, `batch_correction`, and `scaling`.
-- When ComBat support is available, seed presets should also include a `combat` section so users can see the default covariate strategy (`labels`) and advanced options without reading code.
+- ComBat support is available. Seed presets should include a `combat` section so users can see the default covariate strategy (`labels`) and advanced options without reading code.
+- Built-in presets are intentionally conservative: ComBat is not enabled by default, but the `combat` section is present so GUI and CLI users can turn it on with a clear covariate strategy.
+- DNP Step4 marker-aware workflows should use presets/configs that keep `pipeline.impute_method` explicit. `is_Presence_Absence_Marker=True` features are routed to min positive / 5 imputation automatically; non-marker features use the configured method.

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -28,6 +28,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
 from openpyxl.styles import PatternFill  # noqa: E402
+from openpyxl.utils import get_column_letter  # noqa: E402
 
 from core.app_config import apply_cli_overrides, dump_yaml, load_yaml_config  # noqa: E402
 from core.batch_correction import build_combat_design, evaluate_combat_design  # noqa: E402
@@ -454,6 +455,73 @@ def _export_significant_features_excel(
     }
     feature_metadata_by_feature: dict[str, dict[str, Any]] = {}
     summary_metadata_columns: list[str] = []
+    excel_detail_metadata_columns: list[str] = []
+
+    def is_excel_detail_metadata_column(column: str) -> bool:
+        return column in STEP4_REASON_COLUMNS or is_step4_ratio_column(column)
+
+    def apply_step4_excel_outline(worksheet) -> None:
+        headers = [cell.value for cell in worksheet[1]]
+        detail_indexes = [
+            index
+            for index, header in enumerate(headers, start=1)
+            if isinstance(header, str) and is_excel_detail_metadata_column(header)
+        ]
+        if not detail_indexes:
+            return
+
+        worksheet.sheet_properties.outlinePr.summaryRight = True
+        max_column = len(headers)
+        ranges: list[tuple[int, int]] = []
+        start = previous = detail_indexes[0]
+        for index in detail_indexes[1:]:
+            if index == previous + 1:
+                previous = index
+                continue
+            ranges.append((start, previous))
+            start = previous = index
+        ranges.append((start, previous))
+
+        for start, end in ranges:
+            for index in range(start, end + 1):
+                dimension = worksheet.column_dimensions[get_column_letter(index)]
+                dimension.hidden = True
+                dimension.outlineLevel = 1
+            collapsed_index = min(end + 1, max_column)
+            worksheet.column_dimensions[get_column_letter(collapsed_index)].collapsed = True
+
+    def build_summary_excel_df(summary_df: pd.DataFrame) -> pd.DataFrame:
+        if summary_df.empty or not excel_detail_metadata_columns:
+            return summary_df
+
+        excel_df = summary_df.copy()
+        for column in excel_detail_metadata_columns:
+            if column in excel_df.columns:
+                continue
+            excel_df[column] = excel_df["Feature"].map(
+                lambda feat: feature_metadata_by_feature.get(feat, {}).get(column, "")
+            )
+
+        ordered_columns: list[str] = []
+        inserted_details = False
+        for column in excel_df.columns:
+            if column in excel_detail_metadata_columns:
+                continue
+            ordered_columns.append(column)
+            if column == FEATURE_MARKER_COLUMN:
+                ordered_columns.extend(
+                    detail
+                    for detail in excel_detail_metadata_columns
+                    if detail in excel_df.columns
+                )
+                inserted_details = True
+        if not inserted_details:
+            ordered_columns.extend(
+                detail
+                for detail in excel_detail_metadata_columns
+                if detail in excel_df.columns and detail not in ordered_columns
+            )
+        return excel_df.loc[:, ordered_columns]
 
     def passes_threshold(sheet_name: str, row: pd.Series) -> bool:
         name = sheet_name.lower()
@@ -555,15 +623,25 @@ def _export_significant_features_excel(
         metadata_columns = [
             column for column in SUMMARY_STEP4_METADATA_COLUMNS if column in df.columns
         ]
+        excel_metadata_columns = [
+            column for column in df.columns if is_excel_detail_metadata_column(column)
+        ]
         sheet_df = df if top_n in (None, 0) else df.head(top_n)
         for idx, row in sheet_df.iterrows():
             feat = row["Feature"]
             all_features.add(feat)
             if feat not in feature_metadata_by_feature:
                 feature_metadata_by_feature[feat] = {}
+            for column in excel_metadata_columns:
+                if column not in excel_detail_metadata_columns:
+                    excel_detail_metadata_columns.append(column)
             for column in metadata_columns:
                 if column not in summary_metadata_columns:
                     summary_metadata_columns.append(column)
+            for column in excel_metadata_columns:
+                if column not in summary_metadata_columns:
+                    summary_metadata_columns.append(column)
+            for column in list(dict.fromkeys(metadata_columns + excel_metadata_columns)):
                 value = row.get(column)
                 if column in feature_metadata_by_feature[feat] and pd.isna(value):
                     continue
@@ -602,12 +680,13 @@ def _export_significant_features_excel(
         ).reset_index(drop=True)
         summary_df.insert(0, "Rank", range(1, len(summary_df) + 1))
         summary_df.to_csv(summary_csv_path, index=False)
+    summary_excel_df = build_summary_excel_df(summary_df)
 
     # Write all sheets
     with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
         # Summary first
-        if not summary_df.empty:
-            summary_df.to_excel(writer, sheet_name="Summary", index=False)
+        if not summary_excel_df.empty:
+            summary_excel_df.to_excel(writer, sheet_name="Summary", index=False)
 
         # Individual analysis sheets (top_n rows each)
         for sheet_name, df in prepared_sheets.items():
@@ -617,11 +696,14 @@ def _export_significant_features_excel(
             sheet_df.to_excel(writer, sheet_name=safe_name, index=False)
 
         workbook = writer.book
+        if not summary_excel_df.empty:
+            apply_step4_excel_outline(workbook["Summary"])
         for sheet_name, df in prepared_sheets.items():
             sheet_df = df if top_n in (None, 0) else df.head(top_n)
+            safe_name = sheet_name[:31]
+            apply_step4_excel_outline(workbook[safe_name])
             if "significant" not in sheet_df.columns:
                 continue
-            safe_name = sheet_name[:31]
             worksheet = workbook[safe_name]
             significant_col = sheet_df.columns.get_loc("significant") + 1
             for row_idx, value in enumerate(sheet_df["significant"], start=2):

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -74,6 +74,20 @@ warnings.filterwarnings("ignore")
 
 TRUE_FILL = PatternFill(fill_type="solid", start_color="C6EFCE", end_color="C6EFCE")
 FALSE_FILL = PatternFill(fill_type="solid", start_color="FCE4D6", end_color="FCE4D6")
+EVIDENCE_TIER_FILLS = {
+    "Tier1_ConcordantPairwise": PatternFill(
+        fill_type="solid", start_color="FFC6EFCE", end_color="FFC6EFCE"
+    ),
+    "Tier2_MultiMethod": PatternFill(
+        fill_type="solid", start_color="FFD9EAF7", end_color="FFD9EAF7"
+    ),
+    "Tier3_SingleMethod": PatternFill(
+        fill_type="solid", start_color="FFFFF2CC", end_color="FFFFF2CC"
+    ),
+    "Tier0_NoStatEvidence": PatternFill(
+        fill_type="solid", start_color="FFE7E6E6", end_color="FFE7E6E6"
+    ),
+}
 REDUNDANT_EXPORT_COLUMNS = {
     "qc_rsd_exempted",
     "qc_rsd_threshold",
@@ -605,6 +619,18 @@ def _export_significant_features_excel(
             collapsed_index = min(end + 1, max_column)
             worksheet.column_dimensions[get_column_letter(collapsed_index)].collapsed = True
 
+    def apply_evidence_tier_style(worksheet) -> None:
+        headers = [cell.value for cell in worksheet[1]]
+        if EVIDENCE_TIER_COLUMN not in headers:
+            return
+        tier_col = headers.index(EVIDENCE_TIER_COLUMN) + 1
+        worksheet.column_dimensions[get_column_letter(tier_col)].width = 28
+        for row_idx in range(2, worksheet.max_row + 1):
+            cell = worksheet.cell(row=row_idx, column=tier_col)
+            fill = EVIDENCE_TIER_FILLS.get(str(cell.value))
+            if fill is not None:
+                cell.fill = fill
+
     def build_summary_excel_df(summary_df: pd.DataFrame) -> pd.DataFrame:
         if summary_df.empty or not excel_detail_metadata_columns:
             return summary_df
@@ -843,7 +869,9 @@ def _export_significant_features_excel(
 
         workbook = writer.book
         if not summary_excel_df.empty:
-            apply_step4_excel_outline(workbook["Summary"])
+            summary_worksheet = workbook["Summary"]
+            apply_evidence_tier_style(summary_worksheet)
+            apply_step4_excel_outline(summary_worksheet)
         for sheet_name, df in prepared_sheets.items():
             sheet_df = df if top_n in (None, 0) else df.head(top_n)
             safe_name = sheet_name[:31]

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -35,7 +35,6 @@ from core.feature_metadata import (  # noqa: E402
     FEATURE_MARKER_COLUMN,
     STEP4_REASON_COLUMNS,
     extract_feature_metadata,
-    is_step4_feature_metadata_column,
     is_step4_ratio_column,
 )
 from core.input_resolver import (  # noqa: E402
@@ -88,6 +87,7 @@ REPORT_SUBDIRS = {
     "validation": "04_Biomarker_Validation",
     "supplementary": "05_Supplementary",
 }
+SUMMARY_STEP4_METADATA_COLUMNS = (FEATURE_MARKER_COLUMN, *STEP4_REASON_COLUMNS)
 
 
 def _ensure_report_dirs(output_dir: str) -> dict[str, Path]:
@@ -553,7 +553,7 @@ def _export_significant_features_excel(
         if "Feature" not in df.columns:
             continue
         metadata_columns = [
-            column for column in df.columns if is_step4_feature_metadata_column(column)
+            column for column in SUMMARY_STEP4_METADATA_COLUMNS if column in df.columns
         ]
         sheet_df = df if top_n in (None, 0) else df.head(top_n)
         for idx, row in sheet_df.iterrows():

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -35,6 +35,7 @@ from core.feature_metadata import (  # noqa: E402
     FEATURE_MARKER_COLUMN,
     STEP4_REASON_COLUMNS,
     extract_feature_metadata,
+    is_step4_feature_metadata_column,
     is_step4_ratio_column,
 )
 from core.input_resolver import (  # noqa: E402
@@ -451,7 +452,8 @@ def _export_significant_features_excel(
         for sheet_name, df in sheets.items()
         if "oplsda" not in sheet_name.lower()
     }
-    feature_tags: dict[str, bool] = {}
+    feature_metadata_by_feature: dict[str, dict[str, Any]] = {}
+    summary_metadata_columns: list[str] = []
 
     def passes_threshold(sheet_name: str, row: pd.Series) -> bool:
         name = sheet_name.lower()
@@ -550,12 +552,22 @@ def _export_significant_features_excel(
     }.items():
         if "Feature" not in df.columns:
             continue
+        metadata_columns = [
+            column for column in df.columns if is_step4_feature_metadata_column(column)
+        ]
         sheet_df = df if top_n in (None, 0) else df.head(top_n)
         for idx, row in sheet_df.iterrows():
             feat = row["Feature"]
             all_features.add(feat)
-            if feat not in feature_tags and "is_Presence_Absence_Marker" in row.index:
-                feature_tags[feat] = bool(row.get("is_Presence_Absence_Marker", False))
+            if feat not in feature_metadata_by_feature:
+                feature_metadata_by_feature[feat] = {}
+            for column in metadata_columns:
+                if column not in summary_metadata_columns:
+                    summary_metadata_columns.append(column)
+                value = row.get(column)
+                if column in feature_metadata_by_feature[feat] and pd.isna(value):
+                    continue
+                feature_metadata_by_feature[feat][column] = value
             if not passes_threshold(sheet_name, row):
                 continue
             if feat not in feature_counts:
@@ -571,11 +583,14 @@ def _export_significant_features_excel(
     summary_rows = []
     for feat in sorted(all_features):
         appearances = feature_counts.get(feat, {})
+        metadata_values = feature_metadata_by_feature.get(feat, {})
         row = {
             "Feature": feat,
-            "is_Presence_Absence_Marker": feature_tags.get(feat, False),
             "Passed_in_N_analyses": len(appearances),
         }
+        for column in summary_metadata_columns:
+            default_value = False if column == FEATURE_MARKER_COLUMN else ""
+            row[column] = metadata_values.get(column, default_value)
         for sn in all_sheet_names:
             row[sn] = appearances.get(sn, "")
         summary_rows.append(row)

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -31,7 +31,12 @@ from openpyxl.styles import PatternFill  # noqa: E402
 
 from core.app_config import apply_cli_overrides, dump_yaml, load_yaml_config  # noqa: E402
 from core.batch_correction import build_combat_design, evaluate_combat_design  # noqa: E402
-from core.feature_metadata import FEATURE_MARKER_COLUMN, extract_feature_metadata  # noqa: E402
+from core.feature_metadata import (  # noqa: E402
+    FEATURE_MARKER_COLUMN,
+    STEP4_REASON_COLUMNS,
+    extract_feature_metadata,
+    is_step4_ratio_column,
+)
 from core.input_resolver import (  # noqa: E402
     build_labels_from_sample_info,
     detect_sample_type_row_key,
@@ -334,6 +339,21 @@ def load_data(cfg: dict) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
     print(f"  Missing: {data.isna().sum().sum()} / {data.size}")
     marker_count = int(feature_metadata[FEATURE_MARKER_COLUMN].sum())
     print(f"  Presence/absence markers: {marker_count}")
+    if feature_metadata.attrs.get("step4_metadata_detected", False):
+        ratio_columns = [
+            str(column)
+            for column in feature_metadata.columns
+            if is_step4_ratio_column(column)
+        ]
+        reason_columns = [
+            column for column in STEP4_REASON_COLUMNS if column in feature_metadata.columns
+        ]
+        print("  Step4 metadata detected")
+        print(f"  Step4 ratio columns: {len(ratio_columns)}")
+        print(
+            "  Step4 reason columns: "
+            f"{', '.join(reason_columns) if reason_columns else 'none'}"
+        )
 
     return data, labels, feature_metadata
 

--- a/scripts/run_from_config.py
+++ b/scripts/run_from_config.py
@@ -10,6 +10,7 @@ Usage (from project root):
 import argparse
 import json
 import os
+import shutil
 import sys
 import warnings
 from collections.abc import Iterable
@@ -62,7 +63,7 @@ from ms_core.analysis.anova import run_anova  # noqa: E402
 from ms_core.analysis.univariate import volcano_analysis  # noqa: E402
 from ms_core.visualization.pca_plot import plot_pca_score  # noqa: E402
 from ms_core.visualization.anova_plot import plot_anova_importance, plot_feature_boxplot  # noqa: E402
-from visualization.heatmap import plot_heatmap  # noqa: E402
+from visualization.heatmap import plot_grouped_heatmap, plot_heatmap  # noqa: E402
 from visualization.norm_preview import plot_norm_comparison  # noqa: E402
 from visualization.oplsda_plot import plot_oplsda_splot  # noqa: E402
 from visualization.outlier_plot import plot_dmodx, plot_outlier_score  # noqa: E402
@@ -82,6 +83,7 @@ REDUNDANT_EXPORT_COLUMNS = {
     "significance_pvalue",
 }
 REPORT_SUBDIRS = {
+    "review": "00_Review_Pack",
     "qc": "01_QC_and_Preprocessing",
     "global": "02_Global_Profiling",
     "feature": "03_Feature_Selection",
@@ -89,6 +91,13 @@ REPORT_SUBDIRS = {
     "supplementary": "05_Supplementary",
 }
 SUMMARY_STEP4_METADATA_COLUMNS = (FEATURE_MARKER_COLUMN, *STEP4_REASON_COLUMNS)
+EVIDENCE_TIER_COLUMN = "Evidence_Tier"
+EVIDENCE_TIER_ORDER = {
+    "Tier1_ConcordantPairwise": 0,
+    "Tier2_MultiMethod": 1,
+    "Tier3_SingleMethod": 2,
+    "Tier0_NoStatEvidence": 3,
+}
 
 
 def _ensure_report_dirs(output_dir: str) -> dict[str, Path]:
@@ -115,6 +124,38 @@ def _save_figure(
     if save_pdf:
         fig.savefig(path.with_suffix(".pdf"), bbox_inches="tight")
     plt.close(fig)
+
+
+def _copy_review_pack_figures(
+    report_dirs: Mapping[str, Path],
+    report_pairs: list[tuple[str, str]],
+) -> int:
+    """Copy curated PNG figures into the review pack directory."""
+    review_dir = report_dirs["review"]
+    figure_sources: list[Path] = [
+        report_dirs["qc"] / "pca_score_plot.png",
+        report_dirs["global"] / "heatmap_top50_grouped.png",
+        report_dirs["feature"] / "anova_importance.png",
+        report_dirs["supplementary"] / "plsda_score_all_groups.png",
+    ]
+    for group1, group2 in report_pairs:
+        pair_name = f"{group1}_vs_{group2}"
+        figure_sources.extend(
+            [
+                report_dirs["feature"] / f"oplsda_score_{pair_name}.png",
+                report_dirs["feature"] / f"plsda_vip_{pair_name}.png",
+                report_dirs["feature"] / f"volcano_{pair_name}.png",
+            ]
+        )
+
+    copied = 0
+    for source in figure_sources:
+        if not source.is_file():
+            continue
+        copied += 1
+        destination = review_dir / f"{copied:02d}_{source.name}"
+        shutil.copy2(source, destination)
+    return copied
 
 
 def _iter_output_files(output_dir: str) -> Iterable[Path]:
@@ -428,6 +469,79 @@ def _select_heatmap_matrix(
     return df.copy()
 
 
+def _summary_evidence_family(sheet_name: str) -> str | None:
+    """Return the summary evidence family represented by an Excel sheet name."""
+    normalized = sheet_name.strip().lower()
+    if normalized.startswith("anova"):
+        return "anova"
+    if normalized.startswith("vip_"):
+        return "vip"
+    if normalized.startswith("volcano_"):
+        return "volcano"
+    return None
+
+
+def _summary_pair_key(sheet_name: str, family: str | None) -> str | None:
+    """Return a normalized pair key for pairwise evidence sheets."""
+    if family not in {"vip", "volcano"}:
+        return None
+    prefix = f"{family}_"
+    normalized = sheet_name.strip().lower()
+    if not normalized.startswith(prefix):
+        return None
+    pair = normalized[len(prefix) :].strip()
+    return pair or None
+
+
+def _top15_features_for_evidence(sheet_name: str, df: pd.DataFrame) -> set[str]:
+    """Return the feature set eligible for top-15 pair concordance checks."""
+    family = _summary_evidence_family(sheet_name)
+    if family not in {"vip", "volcano"} or "Feature" not in df.columns:
+        return set()
+
+    if family == "vip":
+        if "Rank" in df.columns:
+            ranks = pd.to_numeric(df["Rank"], errors="coerce")
+            top_df = df.loc[ranks <= 15]
+        else:
+            top_df = df.head(15)
+        return set(top_df["Feature"].astype(str))
+
+    sortable = df.copy()
+    if "pvalue_adj" in sortable.columns:
+        sortable["_pvalue_adj_sort"] = pd.to_numeric(
+            sortable["pvalue_adj"], errors="coerce"
+        )
+    else:
+        sortable["_pvalue_adj_sort"] = np.nan
+    top_df = sortable.sort_values(
+        ["_pvalue_adj_sort", "Feature"], ascending=[True, True], na_position="last"
+    ).head(15)
+    return set(top_df["Feature"].astype(str))
+
+
+def _classify_evidence_tier(record: Mapping[str, Any] | None) -> str:
+    """Classify a feature-level cross-method evidence record."""
+    if not record:
+        return "Tier0_NoStatEvidence"
+
+    families = set(record.get("families", set()))
+    vip_top15_pairs = set(record.get("vip_top15_pairs", set()))
+    volcano_top15_pairs = set(record.get("volcano_top15_pairs", set()))
+    vip_pairs = set(record.get("vip_pairs", set()))
+    volcano_pairs = set(record.get("volcano_pairs", set()))
+
+    if vip_top15_pairs & volcano_top15_pairs:
+        return "Tier1_ConcordantPairwise"
+    if "anova" in families and (vip_pairs & volcano_pairs):
+        return "Tier1_ConcordantPairwise"
+    if len(families) >= 2:
+        return "Tier2_MultiMethod"
+    if len(families) == 1:
+        return "Tier3_SingleMethod"
+    return "Tier0_NoStatEvidence"
+
+
 # ── Significant features Excel export ────────────────────
 
 
@@ -456,6 +570,7 @@ def _export_significant_features_excel(
     feature_metadata_by_feature: dict[str, dict[str, Any]] = {}
     summary_metadata_columns: list[str] = []
     excel_detail_metadata_columns: list[str] = []
+    evidence_records: dict[str, dict[str, set[str]]] = {}
 
     def is_excel_detail_metadata_column(column: str) -> bool:
         return column in STEP4_REASON_COLUMNS or is_step4_ratio_column(column)
@@ -620,6 +735,8 @@ def _export_significant_features_excel(
     }.items():
         if "Feature" not in df.columns:
             continue
+        evidence_family = _summary_evidence_family(sheet_name)
+        evidence_pair_key = _summary_pair_key(sheet_name, evidence_family)
         metadata_columns = [
             column for column in SUMMARY_STEP4_METADATA_COLUMNS if column in df.columns
         ]
@@ -627,6 +744,7 @@ def _export_significant_features_excel(
             column for column in df.columns if is_excel_detail_metadata_column(column)
         ]
         sheet_df = df if top_n in (None, 0) else df.head(top_n)
+        top15_features = _top15_features_for_evidence(sheet_name, sheet_df)
         for idx, row in sheet_df.iterrows():
             feat = row["Feature"]
             all_features.add(feat)
@@ -646,7 +764,27 @@ def _export_significant_features_excel(
                 if column in feature_metadata_by_feature[feat] and pd.isna(value):
                     continue
                 feature_metadata_by_feature[feat][column] = value
-            if not passes_threshold(sheet_name, row):
+            passed = passes_threshold(sheet_name, row)
+            if passed and evidence_family is not None:
+                record = evidence_records.setdefault(
+                    feat,
+                    {
+                        "families": set(),
+                        "vip_pairs": set(),
+                        "volcano_pairs": set(),
+                        "vip_top15_pairs": set(),
+                        "volcano_top15_pairs": set(),
+                    },
+                )
+                record["families"].add(evidence_family)
+                if evidence_pair_key is not None and evidence_family in {
+                    "vip",
+                    "volcano",
+                }:
+                    record[f"{evidence_family}_pairs"].add(evidence_pair_key)
+                    if str(feat) in top15_features:
+                        record[f"{evidence_family}_top15_pairs"].add(evidence_pair_key)
+            if not passed:
                 continue
             if feat not in feature_counts:
                 feature_counts[feat] = {}
@@ -664,6 +802,9 @@ def _export_significant_features_excel(
         metadata_values = feature_metadata_by_feature.get(feat, {})
         row = {
             "Feature": feat,
+            EVIDENCE_TIER_COLUMN: _classify_evidence_tier(
+                evidence_records.get(feat)
+            ),
             "Passed_in_N_analyses": len(appearances),
         }
         for column in summary_metadata_columns:
@@ -675,9 +816,14 @@ def _export_significant_features_excel(
 
     summary_df = pd.DataFrame(summary_rows)
     if not summary_df.empty:
+        summary_df["_Evidence_Tier_Rank"] = summary_df[EVIDENCE_TIER_COLUMN].map(
+            EVIDENCE_TIER_ORDER
+        )
         summary_df = summary_df.sort_values(
-            ["Passed_in_N_analyses", "Feature"], ascending=[False, True]
+            ["_Evidence_Tier_Rank", "Passed_in_N_analyses", "Feature"],
+            ascending=[True, False, True],
         ).reset_index(drop=True)
+        summary_df = summary_df.drop(columns=["_Evidence_Tier_Rank"])
         summary_df.insert(0, "Rank", range(1, len(summary_df) + 1))
         summary_df.to_csv(summary_csv_path, index=False)
     summary_excel_df = build_summary_excel_df(summary_df)
@@ -1075,6 +1221,22 @@ def run_analysis(cfg: dict) -> dict[str, str]:
             save_pdf=save_pdf,
         )
         print(f"  Saved {REPORT_SUBDIRS['global']}\\heatmap_top50.png")
+
+        grouped_heatmap_fig = plot_grouped_heatmap(
+            heatmap_df,
+            final_labels.reindex(heatmap_df.index),
+            group_order=included_groups,
+            scale=heatmap_cfg.get("scale", "row"),
+            max_features=None,
+            top_by=str(heatmap_cfg.get("top_by", "var")),
+        )
+        _save_figure(
+            grouped_heatmap_fig,
+            report_dirs["global"] / "heatmap_top50_grouped.png",
+            draft_mode=draft_mode,
+            save_pdf=save_pdf,
+        )
+        print(f"  Saved {REPORT_SUBDIRS['global']}\\heatmap_top50_grouped.png")
 
     anova_pairs = report_pairs
     saved_anova_boxplots = 0
@@ -1541,6 +1703,14 @@ def run_analysis(cfg: dict) -> dict[str, str]:
         )
     except Exception as e:
         print(f"  Excel export error: {e}")
+
+    print("\n" + "=" * 60)
+    print("Building review pack...")
+    copied_review_figures = _copy_review_pack_figures(report_dirs, report_pairs)
+    print(
+        f"  Saved {copied_review_figures} curated PNG(s) to "
+        f"{REPORT_SUBDIRS['review']}"
+    )
 
     # ── Summary ───────────────────────────────────────────
     print("\n" + "=" * 60)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -612,6 +612,45 @@ class TestPipeline:
         assert bool(pipe.step_feature_metadata["qc_rsd"].loc["F_drop", "kept_after_qc_rsd"]) is False
         assert any("Step 3a: QC-RSD filtering" in line for line in pipe.log)
 
+    def test_pipeline_disabled_qc_rsd_does_not_emit_qc_rsd_metadata(self):
+        from core.pipeline import MetaboAnalystPipeline
+
+        df = pd.DataFrame(
+            {
+                "F_marker": [0.0, 0.0, 10.0, 0.0],
+                "F_regular": [1.0, 1.1, 3.0, 4.0],
+            },
+            index=["QC_1", "QC_2", "S1", "S2"],
+        )
+        labels = pd.Series(["QC", "QC", "A", "B"], index=df.index)
+        feature_metadata = pd.DataFrame(
+            {"is_Presence_Absence_Marker": [True, False]},
+            index=["F_marker", "F_regular"],
+        )
+
+        pipe = MetaboAnalystPipeline(df, labels, feature_metadata=feature_metadata)
+        pipe.run_pipeline(
+            missing_thresh=1.0,
+            impute_method="knn",
+            filter_method="None",
+            row_norm="None",
+            transform="None",
+            scaling="None",
+            qc_rsd_enabled=False,
+            qc_rsd_threshold=0.50,
+        )
+
+        assert pipe.processed_feature_metadata is not None
+        assert "qc_rsd" not in pipe.step_feature_metadata
+        assert not {
+            "qc_rsd",
+            "qc_rsd_threshold",
+            "qc_detect_ratio",
+            "qc_rsd_pass",
+            "qc_rsd_exempted",
+            "kept_after_qc_rsd",
+        }.intersection(pipe.processed_feature_metadata.columns)
+
     def test_pipeline_marker_aware_imputation_and_qc_rsd_exemption(self):
         from core.pipeline import MetaboAnalystPipeline
 

--- a/tests/test_grouped_heatmap.py
+++ b/tests/test_grouped_heatmap.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from visualization.heatmap import order_samples_for_grouped_heatmap
+
+
+def test_grouped_heatmap_order_uses_configured_group_order_then_unknown_groups():
+    data = pd.DataFrame(
+        {"F1": [1.0, 2.0, 3.0, 4.0]},
+        index=["N_1", "E_1", "X_1", "E_2"],
+    )
+    labels = pd.Series(
+        ["Normal", "Exposure", "Other", "Exposure"],
+        index=data.index,
+        name="Group",
+    )
+
+    ordered_data, ordered_labels = order_samples_for_grouped_heatmap(
+        data,
+        labels,
+        group_order=["Exposure", "Normal"],
+    )
+
+    assert ordered_data.index.tolist() == ["E_1", "E_2", "N_1", "X_1"]
+    assert ordered_labels.tolist() == ["Exposure", "Exposure", "Normal", "Other"]

--- a/tests/test_grouped_heatmap.py
+++ b/tests/test_grouped_heatmap.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from visualization.heatmap import order_samples_for_grouped_heatmap
+from visualization.heatmap import order_samples_for_grouped_heatmap, plot_grouped_heatmap
 
 
 def test_grouped_heatmap_order_uses_configured_group_order_then_unknown_groups():
@@ -24,3 +24,30 @@ def test_grouped_heatmap_order_uses_configured_group_order_then_unknown_groups()
 
     assert ordered_data.index.tolist() == ["E_1", "E_2", "N_1", "X_1"]
     assert ordered_labels.tolist() == ["Exposure", "Exposure", "Normal", "Other"]
+
+
+def test_grouped_heatmap_uses_left_group_labels_without_right_legend():
+    data = pd.DataFrame(
+        {
+            "F1": [1.0, 2.0, 3.0, 4.0],
+            "F2": [4.0, 3.0, 2.0, 1.0],
+        },
+        index=["E_1", "E_2", "N_1", "N_2"],
+    )
+    labels = pd.Series(
+        ["Exposure", "Exposure", "Normal", "Normal"],
+        index=data.index,
+        name="Group",
+    )
+
+    fig = plot_grouped_heatmap(
+        data,
+        labels,
+        group_order=["Exposure", "Normal"],
+        scale=None,
+    )
+
+    assert all(ax.get_legend() is None for ax in fig.axes)
+    assert fig.axes[1].get_ylabel() == ""
+    group_text = {text.get_text() for text in fig.axes[0].texts}
+    assert {"Exposure", "Normal"}.issubset(group_text)

--- a/tests/test_gui_runtime_feature_metadata.py
+++ b/tests/test_gui_runtime_feature_metadata.py
@@ -24,6 +24,26 @@ def _make_column_oriented_raw_df() -> pd.DataFrame:
             "S1": ["A", 10.0, 3.0, 20.0],
             "S2": ["B", 0.0, 4.0, 30.0],
             FEATURE_MARKER_COLUMN: [FEATURE_MARKER_COLUMN, True, False, False],
+            "Feature_Filter_Keep_Reasons": [
+                "Feature_Filter_Keep_Reasons",
+                "mnar",
+                "stable",
+                "stable",
+            ],
+            "Imputation_Tag_Reasons": [
+                "Imputation_Tag_Reasons",
+                "low_overall_detection",
+                "",
+                "",
+            ],
+            "exposure_ratio": ["exposure_ratio", 0.5, 1.0, 1.0],
+            "QC_ratio": ["QC_ratio", 1.0, 1.0, 1.0],
+            "Detection_Profile": [
+                "Detection_Profile",
+                "legacy_marker",
+                "legacy_regular",
+                "legacy_drop",
+            ],
             "Original_CV%": [None, 10.0, 20.0, 30.0],
         }
     )
@@ -87,6 +107,14 @@ def test_gui_import_pipeline_retains_feature_metadata(qapp) -> None:
     assert window.raw_feature_metadata is not None
     assert window.raw_feature_metadata.index.tolist() == ["F_marker", "F_regular", "F_drop"]
     assert window.raw_feature_metadata[FEATURE_MARKER_COLUMN].tolist() == [True, False, False]
+    assert window.raw_feature_metadata["Feature_Filter_Keep_Reasons"].tolist() == [
+        "mnar",
+        "stable",
+        "stable",
+    ]
+    assert window.raw_feature_metadata["exposure_ratio"].tolist() == [0.5, 1.0, 1.0]
+    assert "Step4 metadata detected" in window.import_tab.info_text.toPlainText()
+    assert "Presence/absence markers: 1" in window.import_tab.info_text.toPlainText()
 
     window.set_pipeline_params(**_marker_aware_params())
     payload = window.run_pipeline_until("filter")

--- a/tests/test_publication_batch_report_smoke.py
+++ b/tests/test_publication_batch_report_smoke.py
@@ -290,6 +290,9 @@ def _install_smoke_stubs(
         run_mod, "plot_feature_boxplot", _stub_plot("ANOVA Feature Boxplot")
     )
     monkeypatch.setattr(run_mod, "plot_heatmap", _stub_plot("Heatmap"))
+    monkeypatch.setattr(
+        run_mod, "plot_grouped_heatmap", _stub_plot("Grouped Heatmap")
+    )
     monkeypatch.setattr(run_mod, "plot_oplsda_splot", _stub_plot("OPLS-DA S-Plot"))
     monkeypatch.setattr(run_mod, "plot_outlier_score", _stub_plot("Outlier T2"))
     monkeypatch.setattr(run_mod, "plot_dmodx", _stub_plot("Outlier DModX"))
@@ -397,6 +400,7 @@ def test_publication_report_smoke_layout_and_pruning(
 
     output_dir = Path(result["output_dir"])
     expected_dirs = [
+        output_dir / "00_Review_Pack",
         output_dir / "01_QC_and_Preprocessing",
         output_dir / "02_Global_Profiling",
         output_dir / "03_Feature_Selection",
@@ -416,6 +420,7 @@ def test_publication_report_smoke_layout_and_pruning(
         output_dir / "01_QC_and_Preprocessing" / "normalization_comparison.png",
         output_dir / "01_QC_and_Preprocessing" / "pca_score_plot.png",
         output_dir / "02_Global_Profiling" / "heatmap_top50.png",
+        output_dir / "02_Global_Profiling" / "heatmap_top50_grouped.png",
         output_dir / "03_Feature_Selection" / "oplsda_score_Exposure_vs_Normal.png",
         output_dir / "03_Feature_Selection" / "oplsda_splot_Exposure_vs_Normal.png",
         output_dir / "03_Feature_Selection" / "volcano_Exposure_vs_Normal.png",
@@ -429,6 +434,15 @@ def test_publication_report_smoke_layout_and_pruning(
         output_dir / "05_Supplementary" / "rf_importance_Exposure_vs_Normal.png",
         output_dir / "05_Supplementary" / "rf_confusion_matrix_Exposure_vs_Normal.png",
         output_dir / "05_Supplementary" / "anova_boxplot_Exposure_vs_Normal_top1.png",
+        output_dir / "00_Review_Pack" / "01_pca_score_plot.png",
+        output_dir / "00_Review_Pack" / "02_heatmap_top50_grouped.png",
+        output_dir / "00_Review_Pack" / "03_anova_importance.png",
+        output_dir / "00_Review_Pack" / "04_plsda_score_all_groups.png",
+        output_dir
+        / "00_Review_Pack"
+        / "05_oplsda_score_Exposure_vs_Normal.png",
+        output_dir / "00_Review_Pack" / "06_plsda_vip_Exposure_vs_Normal.png",
+        output_dir / "00_Review_Pack" / "07_volcano_Exposure_vs_Normal.png",
     ]
     legacy_files = [
         output_dir / "pca_scree_plot.png",

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -660,6 +660,8 @@ def test_summary_export_keeps_step4_metadata_columns(tmp_path: Path):
                 "is_Presence_Absence_Marker": [True, False],
                 "Feature_Filter_Keep_Reasons": ["stable|mnar", "stable"],
                 "Imputation_Tag_Reasons": ["low_overall_detection", ""],
+                "exposure_ratio": [0.1, 1.0],
+                "QC_ratio": [1.0, 1.0],
             }
         ),
         "Volcano_Tumor_vs_Normal": pd.DataFrame(
@@ -670,6 +672,8 @@ def test_summary_export_keeps_step4_metadata_columns(tmp_path: Path):
                 "is_Presence_Absence_Marker": [True, False],
                 "Feature_Filter_Keep_Reasons": ["stable|mnar", "stable"],
                 "Imputation_Tag_Reasons": ["low_overall_detection", ""],
+                "exposure_ratio": [0.1, 1.0],
+                "QC_ratio": [1.0, 1.0],
             }
         ),
     }
@@ -680,6 +684,8 @@ def test_summary_export_keeps_step4_metadata_columns(tmp_path: Path):
 
     assert "Feature_Filter_Keep_Reasons" in summary_df.columns
     assert "Imputation_Tag_Reasons" in summary_df.columns
+    assert "exposure_ratio" not in summary_df.columns
+    assert "QC_ratio" not in summary_df.columns
     marker_row = summary_df.set_index("Feature").loc["F_marker"]
     assert marker_row["Feature_Filter_Keep_Reasons"] == "stable|mnar"
     assert marker_row["Imputation_Tag_Reasons"] == "low_overall_detection"

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -782,5 +782,17 @@ def test_summary_export_assigns_evidence_tiers(tmp_path: Path):
     assert summary_df["Feature"].iloc[0] == "F_tier1"
 
     workbook = load_workbook(tmp_path / "significant_features_summary.xlsx")
-    headers = [cell.value for cell in workbook["Summary"][1]]
+    worksheet = workbook["Summary"]
+    headers = [cell.value for cell in worksheet[1]]
     assert headers[:3] == ["Rank", "Feature", "Evidence_Tier"]
+    tier_col = headers.index("Evidence_Tier") + 1
+    tier_fills = {
+        worksheet.cell(row=row_idx, column=2).value: worksheet.cell(
+            row=row_idx, column=tier_col
+        ).fill.fgColor.rgb
+        for row_idx in range(2, worksheet.max_row + 1)
+    }
+    assert tier_fills["F_tier1"] == "FFC6EFCE"
+    assert tier_fills["F_tier2"] == "FFD9EAF7"
+    assert tier_fills["F_tier3"] == "FFFFF2CC"
+    assert tier_fills["F_none"] == "FFE7E6E6"

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -716,3 +716,71 @@ def test_summary_export_keeps_step4_metadata_columns(tmp_path: Path):
             letter = get_column_letter(headers.index(column) + 1)
             assert worksheet.column_dimensions[letter].hidden is True
             assert worksheet.column_dimensions[letter].outlineLevel == 1
+
+
+def test_summary_export_assigns_evidence_tiers(tmp_path: Path):
+    sheets = {
+        "ANOVA_All": pd.DataFrame(
+            {
+                "Feature": [
+                    "F_tier1",
+                    "F_tier2",
+                    "F_tier3",
+                    "F_cross_pair_only",
+                    "F_none",
+                ],
+                "pvalue_adj": [0.01, 0.02, 0.60, 0.80, 0.90],
+                "pvalue": [0.01, 0.02, 0.60, 0.80, 0.90],
+                "neg_log10p": [2.0, 1.7, 0.2, 0.1, 0.05],
+                "significant": [True, True, False, False, False],
+                "is_Presence_Absence_Marker": [False] * 5,
+            }
+        ),
+        "VIP_Tumor_vs_Normal": pd.DataFrame(
+            {
+                "Rank": [1, 2, 3, 4, 5],
+                "Feature": [
+                    "F_tier1",
+                    "F_tier2",
+                    "F_tier3",
+                    "F_cross_pair_only",
+                    "F_none",
+                ],
+                "VIP": [2.0, 1.4, 1.3, 1.6, 0.3],
+                "is_Presence_Absence_Marker": [False] * 5,
+            }
+        ),
+        "Volcano_Tumor_vs_Normal": pd.DataFrame(
+            {
+                "Feature": ["F_tier1", "F_tier2", "F_none"],
+                "log2FC": [1.5, 0.2, 0.1],
+                "pvalue_adj": [0.001, 0.80, 0.90],
+                "is_Presence_Absence_Marker": [False, False, False],
+            }
+        ),
+        "Volcano_Tumor_vs_Control": pd.DataFrame(
+            {
+                "Feature": ["F_cross_pair_only"],
+                "log2FC": [1.6],
+                "pvalue_adj": [0.002],
+                "is_Presence_Absence_Marker": [False],
+            }
+        ),
+    }
+
+    _export_significant_features_excel(sheets, str(tmp_path), top_n=None)
+
+    summary_df = pd.read_csv(tmp_path / "Summary.csv")
+    tiers = summary_df.set_index("Feature")["Evidence_Tier"].to_dict()
+
+    assert tiers["F_tier1"] == "Tier1_ConcordantPairwise"
+    assert tiers["F_tier2"] == "Tier2_MultiMethod"
+    assert tiers["F_tier3"] == "Tier3_SingleMethod"
+    assert tiers["F_cross_pair_only"] == "Tier2_MultiMethod"
+    assert tiers["F_none"] == "Tier0_NoStatEvidence"
+    assert summary_df.columns[:3].tolist() == ["Rank", "Feature", "Evidence_Tier"]
+    assert summary_df["Feature"].iloc[0] == "F_tier1"
+
+    workbook = load_workbook(tmp_path / "significant_features_summary.xlsx")
+    headers = [cell.value for cell in workbook["Summary"][1]]
+    assert headers[:3] == ["Rank", "Feature", "Evidence_Tier"]

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -648,3 +648,38 @@ def test_summary_export_keeps_features_with_zero_significant_hits(tmp_path: Path
     assert summary_df["Feature"].tolist() == ["F_keep", "F_zero"]
     assert summary_df["Passed_in_N_analyses"].tolist() == [2, 0]
     assert summary_df["is_Presence_Absence_Marker"].tolist() == [False, True]
+
+
+def test_summary_export_keeps_step4_metadata_columns(tmp_path: Path):
+    sheets = {
+        "VIP_Tumor_vs_Normal": pd.DataFrame(
+            {
+                "Rank": [1, 2],
+                "Feature": ["F_marker", "F_regular"],
+                "VIP": [1.4, 0.2],
+                "is_Presence_Absence_Marker": [True, False],
+                "Feature_Filter_Keep_Reasons": ["stable|mnar", "stable"],
+                "Imputation_Tag_Reasons": ["low_overall_detection", ""],
+            }
+        ),
+        "Volcano_Tumor_vs_Normal": pd.DataFrame(
+            {
+                "Feature": ["F_marker", "F_regular"],
+                "log2FC": [2.0, 0.1],
+                "pvalue_adj": [0.01, 0.8],
+                "is_Presence_Absence_Marker": [True, False],
+                "Feature_Filter_Keep_Reasons": ["stable|mnar", "stable"],
+                "Imputation_Tag_Reasons": ["low_overall_detection", ""],
+            }
+        ),
+    }
+
+    _export_significant_features_excel(sheets, str(tmp_path), top_n=None)
+
+    summary_df = pd.read_csv(tmp_path / "Summary.csv")
+
+    assert "Feature_Filter_Keep_Reasons" in summary_df.columns
+    assert "Imputation_Tag_Reasons" in summary_df.columns
+    marker_row = summary_df.set_index("Feature").loc["F_marker"]
+    assert marker_row["Feature_Filter_Keep_Reasons"] == "stable|mnar"
+    assert marker_row["Imputation_Tag_Reasons"] == "low_overall_detection"

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
 
 from core.input_resolver import read_input_table, resolve_primary_sheet_name_from_names
 from scripts.run_from_config import (
@@ -684,8 +686,33 @@ def test_summary_export_keeps_step4_metadata_columns(tmp_path: Path):
 
     assert "Feature_Filter_Keep_Reasons" in summary_df.columns
     assert "Imputation_Tag_Reasons" in summary_df.columns
-    assert "exposure_ratio" not in summary_df.columns
-    assert "QC_ratio" not in summary_df.columns
+    assert "exposure_ratio" in summary_df.columns
+    assert "QC_ratio" in summary_df.columns
     marker_row = summary_df.set_index("Feature").loc["F_marker"]
     assert marker_row["Feature_Filter_Keep_Reasons"] == "stable|mnar"
     assert marker_row["Imputation_Tag_Reasons"] == "low_overall_detection"
+    assert marker_row["exposure_ratio"] == 0.1
+    assert marker_row["QC_ratio"] == 1.0
+
+    workbook = load_workbook(tmp_path / "significant_features_summary.xlsx")
+    for sheet_name in ["Summary", "VIP_Tumor_vs_Normal"]:
+        worksheet = workbook[sheet_name]
+        headers = [cell.value for cell in worksheet[1]]
+        assert "is_Presence_Absence_Marker" in headers
+        assert "Feature_Filter_Keep_Reasons" in headers
+        assert "Imputation_Tag_Reasons" in headers
+        assert "exposure_ratio" in headers
+        assert "QC_ratio" in headers
+
+        marker_letter = get_column_letter(headers.index("is_Presence_Absence_Marker") + 1)
+        assert not worksheet.column_dimensions[marker_letter].hidden
+
+        for column in [
+            "Feature_Filter_Keep_Reasons",
+            "Imputation_Tag_Reasons",
+            "exposure_ratio",
+            "QC_ratio",
+        ]:
+            letter = get_column_letter(headers.index(column) + 1)
+            assert worksheet.column_dimensions[letter].hidden is True
+            assert worksheet.column_dimensions[letter].outlineLevel == 1

--- a/tests/test_run_from_config_input_formats.py
+++ b/tests/test_run_from_config_input_formats.py
@@ -5,6 +5,7 @@ import pytest
 
 from core.input_resolver import read_input_table, resolve_primary_sheet_name_from_names
 from scripts.run_from_config import (
+    _annotate_feature_table,
     _export_significant_features_excel,
     load_data,
     resolve_top_vip,
@@ -106,6 +107,148 @@ def test_load_data_sample_type_row_excludes_non_sample_columns_even_if_labeled(
     assert feature_metadata["is_Presence_Absence_Marker"].tolist() == [False, False]
 
 
+def test_load_data_sample_type_row_preserves_step4_metadata(tmp_path: Path):
+    xlsx_path = tmp_path / "test_step4_metadata.xlsx"
+    df = pd.DataFrame(
+        {
+            "FeatureID": ["Sample_Type", "F_marker", "F_regular"],
+            "QC_1": ["QC", 0.0, 1.2],
+            "Sample_A": ["Exposure", 10.0, 3.0],
+            "Sample_B": ["Normal", 0.0, 4.0],
+            "Original_CV%": ["Control", 10.0, 20.0],
+            "exposure_ratio": ["Control", "0.10", "0.95"],
+            "normal_ratio": ["Control", "0.00", "1.00"],
+            "QC_ratio": ["QC", "1.00", "1.00"],
+            "is_Presence_Absence_Marker": ["is_Presence_Absence_Marker", "TRUE", "0.0"],
+            "Feature_Filter_Keep_Reasons": [
+                "Feature_Filter_Keep_Reasons",
+                "stable|mnar",
+                "stable",
+            ],
+            "Imputation_Tag_Reasons": [
+                "Imputation_Tag_Reasons",
+                "low_overall_detection",
+                "",
+            ],
+            "Detection_Profile": ["Detection_Profile", "legacy_marker", "legacy_regular"],
+        }
+    )
+    _write_excel_with_sample_info(
+        xlsx_path,
+        df,
+        _sample_info(["QC_1", "Sample_A", "Sample_B"], ["QC", "Exposure", "Normal"]),
+    )
+
+    data, labels, feature_metadata = load_data(
+        {
+            "input": {
+                "file": str(xlsx_path),
+                "format": "sample_type_row",
+            }
+        }
+    )
+
+    assert list(data.index) == ["QC_1", "Sample_A", "Sample_B"]
+    assert list(data.columns) == ["F_marker", "F_regular"]
+    assert labels.to_dict() == {"QC_1": "QC", "Sample_A": "Exposure", "Sample_B": "Normal"}
+    assert feature_metadata["is_Presence_Absence_Marker"].tolist() == [True, False]
+    assert feature_metadata["Feature_Filter_Keep_Reasons"].tolist() == ["stable|mnar", "stable"]
+    assert feature_metadata["Imputation_Tag_Reasons"].fillna("").tolist() == [
+        "low_overall_detection",
+        "",
+    ]
+    assert feature_metadata["Detection_Profile"].tolist() == ["legacy_marker", "legacy_regular"]
+    assert feature_metadata["exposure_ratio"].tolist() == [0.10, 0.95]
+    assert feature_metadata["normal_ratio"].tolist() == [0.00, 1.00]
+    assert feature_metadata["QC_ratio"].tolist() == [1.00, 1.00]
+
+
+def test_load_data_step4_metadata_requires_marker_column(tmp_path: Path):
+    xlsx_path = tmp_path / "test_step4_missing_marker.xlsx"
+    df = pd.DataFrame(
+        {
+            "FeatureID": ["Sample_Type", "F1"],
+            "Sample_A": ["Exposure", 1.0],
+            "Sample_B": ["Normal", 2.0],
+            "Feature_Filter_Keep_Reasons": ["Feature_Filter_Keep_Reasons", "stable"],
+        }
+    )
+    _write_excel_with_sample_info(
+        xlsx_path,
+        df,
+        _sample_info(["Sample_A", "Sample_B"], ["Exposure", "Normal"]),
+    )
+
+    with pytest.raises(ValueError, match="is_Presence_Absence_Marker"):
+        load_data(
+            {
+                "input": {
+                    "file": str(xlsx_path),
+                    "format": "sample_type_row",
+                }
+            }
+        )
+
+
+def test_load_data_rejects_invalid_presence_absence_marker(tmp_path: Path):
+    xlsx_path = tmp_path / "test_step4_invalid_marker.xlsx"
+    df = pd.DataFrame(
+        {
+            "FeatureID": ["Sample_Type", "F1"],
+            "Sample_A": ["Exposure", 1.0],
+            "Sample_B": ["Normal", 2.0],
+            "is_Presence_Absence_Marker": ["is_Presence_Absence_Marker", "maybe"],
+        }
+    )
+    _write_excel_with_sample_info(
+        xlsx_path,
+        df,
+        _sample_info(["Sample_A", "Sample_B"], ["Exposure", "Normal"]),
+    )
+
+    with pytest.raises(ValueError, match="Invalid is_Presence_Absence_Marker"):
+        load_data(
+            {
+                "input": {
+                    "file": str(xlsx_path),
+                    "format": "sample_type_row",
+                }
+            }
+        )
+
+
+def test_load_data_step4_reason_columns_are_optional(tmp_path: Path):
+    xlsx_path = tmp_path / "test_step4_optional_reasons.xlsx"
+    df = pd.DataFrame(
+        {
+            "FeatureID": ["Sample_Type", "F1"],
+            "Sample_A": ["Exposure", 1.0],
+            "Sample_B": ["Normal", 2.0],
+            "exposure_ratio": ["Exposure", "1.0"],
+            "is_Presence_Absence_Marker": ["is_Presence_Absence_Marker", "false"],
+        }
+    )
+    _write_excel_with_sample_info(
+        xlsx_path,
+        df,
+        _sample_info(["Sample_A", "Sample_B"], ["Exposure", "Normal"]),
+    )
+
+    _data, _labels, feature_metadata = load_data(
+        {
+            "input": {
+                "file": str(xlsx_path),
+                "format": "sample_type_row",
+            }
+        }
+    )
+
+    assert feature_metadata["is_Presence_Absence_Marker"].tolist() == [False]
+    assert "Feature_Filter_Keep_Reasons" not in feature_metadata.columns
+    assert "Imputation_Tag_Reasons" not in feature_metadata.columns
+    assert feature_metadata["exposure_ratio"].tolist() == [1.0]
+
+
 def test_load_data_plain_excludes_summary_columns(tmp_path: Path):
     xlsx_path = tmp_path / "test_plain_non_sample_cols.xlsx"
     df = pd.DataFrame(
@@ -176,7 +319,7 @@ def test_load_data_plain_extracts_presence_absence_marker_metadata(tmp_path: Pat
             "Tumor_A": [1.0, 3.0, 0.0],
             "Normal_B": [2.0, 4.0, 0.0],
             "is_Presence_Absence_Marker": [
-                "is_Presence_Absence_Marker",
+                False,
                 True,
                 False,
             ],
@@ -202,6 +345,24 @@ def test_load_data_plain_extracts_presence_absence_marker_metadata(tmp_path: Pat
     assert labels.to_dict() == {"Tumor_A": "Tumor", "Normal_B": "Normal"}
     assert feature_metadata.index.tolist() == ["100.1/1.1", "200.2/2.2", "300.3/3.3"]
     assert feature_metadata["is_Presence_Absence_Marker"].tolist() == [False, True, False]
+
+
+def test_annotate_feature_table_preserves_step4_metadata_columns():
+    feature_metadata = pd.DataFrame(
+        {
+            "is_Presence_Absence_Marker": [True, False],
+            "Feature_Filter_Keep_Reasons": ["mnar", "stable"],
+            "exposure_ratio": [0.1, 1.0],
+        },
+        index=pd.Index(["F1", "F2"], name="Feature"),
+    )
+    stats_df = pd.DataFrame({"Feature": ["F2", "F1"], "pvalue": [0.2, 0.01]})
+
+    annotated = _annotate_feature_table(stats_df, feature_metadata)
+
+    assert annotated["is_Presence_Absence_Marker"].tolist() == [False, True]
+    assert annotated["Feature_Filter_Keep_Reasons"].tolist() == ["stable", "mnar"]
+    assert annotated["exposure_ratio"].tolist() == [1.0, 0.1]
 
 
 def test_load_data_plain_excel_without_sample_info_falls_back_to_name_inference(tmp_path: Path):

--- a/tests/test_sample_interface.py
+++ b/tests/test_sample_interface.py
@@ -94,7 +94,16 @@ def test_normalize_sample_name_matches_cross_tool_formatting():
 def test_identify_sample_columns_excludes_summary_and_metadata_columns():
     from core.sample_interface import identify_sample_columns
 
-    sample_columns = identify_sample_columns(_make_matrix_df())
+    matrix_df = _make_matrix_df().assign(
+        Feature_Filter_Keep_Reasons=["Feature_Filter_Keep_Reasons", "stable", "mnar"],
+        Imputation_Tag_Reasons=["Imputation_Tag_Reasons", "", "low_overall_detection"],
+        Feature_Filter_Delete_Reasons=["Feature_Filter_Delete_Reasons", "", ""],
+        Detection_Profile=["Detection_Profile", "legacy", "legacy"],
+        exposure_ratio=["exposure_ratio", 1.0, 0.1],
+        QC_ratio=["QC_ratio", 1.0, 1.0],
+    )
+
+    sample_columns = identify_sample_columns(matrix_df)
 
     assert sample_columns == [
         "Breast_Cancer_Tissue_pooled_QC_1",

--- a/visualization/__init__.py
+++ b/visualization/__init__.py
@@ -39,7 +39,7 @@ from visualization.correlation_plot import (  # noqa: E402
     plot_correlation_network_interactive,
 )
 from visualization.density_plot import plot_density  # noqa: E402
-from visualization.heatmap import plot_heatmap  # noqa: E402
+from visualization.heatmap import plot_grouped_heatmap, plot_heatmap  # noqa: E402
 from visualization.norm_preview import plot_norm_comparison  # noqa: E402
 from visualization.outlier_plot import plot_dmodx, plot_outlier_score  # noqa: E402
 from visualization.oplsda_plot import plot_oplsda_score, plot_oplsda_splot  # noqa: E402
@@ -63,6 +63,7 @@ __all__ = [
     "plot_feature_boxplot",
     "plot_feature_boxplot_paired",
     "plot_group_boxplot",
+    "plot_grouped_heatmap",
     "plot_heatmap",
     "plot_norm_comparison",
     "plot_oplsda_score",

--- a/visualization/heatmap.py
+++ b/visualization/heatmap.py
@@ -11,7 +11,6 @@ import seaborn as sns
 from matplotlib.colors import ListedColormap
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
-from matplotlib.patches import Patch
 
 from ms_core.analysis.clustering import select_top_features
 from visualization.theme import apply_publication_style, get_group_colors
@@ -91,8 +90,8 @@ def plot_grouped_heatmap(
     grid = GridSpec(
         1,
         3,
-        width_ratios=[0.18, 5.0, 0.22],
-        wspace=0.04,
+        width_ratios=[0.46, 5.0, 0.16],
+        wspace=0.03,
         figure=fig,
     )
     ax_group = fig.add_subplot(grid[0, 0])
@@ -107,20 +106,24 @@ def plot_grouped_heatmap(
     )
     ax_group.set_xticks([])
     ax_group.set_yticks([])
-    ax_group.set_ylabel("Group", fontsize=9)
+    ax_group.set_ylabel("")
 
     sns.heatmap(
         plot_df,
         cmap="RdBu_r",
         ax=ax_heat,
         cbar_ax=ax_cbar,
-        xticklabels=plot_df.shape[1] <= 50,
+        xticklabels=plot_df.shape[1] <= 35,
         yticklabels=plot_df.shape[0] <= 50,
         linewidths=0,
     )
-    ax_heat.set_title("Grouped Heatmap (Top ANOVA-ranked Features)", fontsize=12)
-    ax_heat.set_xlabel("Features")
-    ax_heat.set_ylabel("Samples")
+    ax_heat.set_title("Grouped Heatmap: Top 50 ANOVA Features", fontsize=11)
+    ax_heat.set_xlabel("Features", fontsize=9)
+    ax_heat.set_ylabel("")
+    ax_heat.tick_params(axis="x", labelsize=7)
+    ax_heat.tick_params(axis="y", labelsize=7)
+    ax_cbar.tick_params(labelsize=8)
+    ax_cbar.set_ylabel("Scaled intensity", fontsize=8)
 
     boundaries: list[int] = []
     previous = None
@@ -132,17 +135,24 @@ def plot_grouped_heatmap(
         ax_group.axhline(boundary - 0.5, color="white", linewidth=1.2)
         ax_heat.axhline(boundary, color="black", linewidth=0.7)
 
-    legend_handles = [
-        Patch(facecolor=palette[group], edgecolor="none", label=group) for group in groups
-    ]
-    ax_heat.legend(
-        handles=legend_handles,
-        loc="upper left",
-        bbox_to_anchor=(1.02, 1.0),
-        fontsize=8,
-        title="Group",
-    )
-    fig.tight_layout()
+    group_values = ordered_labels.astype(str).tolist()
+    for group in groups:
+        positions = [index for index, value in enumerate(group_values) if value == group]
+        if not positions:
+            continue
+        center = (positions[0] + positions[-1]) / 2
+        ax_group.text(
+            0,
+            center,
+            group,
+            ha="center",
+            va="center",
+            fontsize=8.5,
+            fontweight="bold",
+            color="black",
+        )
+
+    fig.subplots_adjust(left=0.04, right=0.95, top=0.90, bottom=0.12)
     return fig
 
 

--- a/visualization/heatmap.py
+++ b/visualization/heatmap.py
@@ -2,14 +2,148 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from matplotlib.colors import ListedColormap
 from matplotlib.figure import Figure
+from matplotlib.gridspec import GridSpec
+from matplotlib.patches import Patch
 
 from ms_core.analysis.clustering import select_top_features
 from visualization.theme import apply_publication_style, get_group_colors
+
+
+def order_samples_for_grouped_heatmap(
+    df: pd.DataFrame,
+    labels,
+    group_order: list[str] | tuple[str, ...] | None = None,
+) -> tuple[pd.DataFrame, pd.Series]:
+    """Return data and labels ordered by configured group order, preserving row order."""
+    label_series = (
+        pd.Series(labels, index=df.index, name="Group")
+        .reindex(df.index)
+        .fillna("Unknown")
+    )
+    label_series = label_series.astype(str)
+    observed_groups = label_series.unique().tolist()
+    configured = [str(group) for group in (group_order or [])]
+    ordered_groups = [group for group in configured if group in observed_groups]
+    ordered_groups.extend(
+        group for group in observed_groups if group not in ordered_groups
+    )
+
+    ordered_index: list[Any] = []
+    for group in ordered_groups:
+        ordered_index.extend(label_series.index[label_series == group].tolist())
+    ordered_index.extend(index for index in df.index if index not in ordered_index)
+    return df.loc[ordered_index].copy(), label_series.loc[ordered_index].copy()
+
+
+def _standard_scale_heatmap_data(df: pd.DataFrame, scale: str | None) -> pd.DataFrame:
+    """Mirror seaborn clustermap standard_scale behavior for fixed-order heatmaps."""
+    if scale not in {"row", "col"}:
+        return df
+
+    axis = 1 if scale == "row" else 0
+    mins = df.min(axis=axis)
+    shifted = df.sub(mins, axis=0 if scale == "row" else 1)
+    maxes = shifted.max(axis=axis).replace(0, np.nan)
+    scaled = shifted.div(maxes, axis=0 if scale == "row" else 1)
+    return scaled.fillna(0.0)
+
+
+def plot_grouped_heatmap(
+    df: pd.DataFrame,
+    labels,
+    *,
+    group_order: list[str] | tuple[str, ...] | None = None,
+    scale: str | None = "row",
+    max_features: int | None = None,
+    top_by: str = "var",
+    theme: str = "light",
+    fig: Figure | None = None,
+) -> Figure:
+    """Plot a review-friendly heatmap with samples grouped by sample class."""
+    apply_publication_style(theme)
+    plot_df = df.copy()
+    if max_features is not None and plot_df.shape[1] > max_features:
+        plot_df = select_top_features(plot_df, max_features=max_features, by=top_by)
+    plot_df, ordered_labels = order_samples_for_grouped_heatmap(
+        plot_df,
+        labels,
+        group_order=group_order,
+    )
+    plot_df = _standard_scale_heatmap_data(plot_df, scale)
+
+    groups = [str(group) for group in ordered_labels.dropna().unique()]
+    palette = dict(zip(groups, get_group_colors(theme, len(groups))))
+    group_codes = np.array([groups.index(str(group)) for group in ordered_labels])
+
+    if fig is None:
+        fig = plt.figure(figsize=(12, 8))
+    else:
+        fig.clear()
+
+    grid = GridSpec(
+        1,
+        3,
+        width_ratios=[0.18, 5.0, 0.22],
+        wspace=0.04,
+        figure=fig,
+    )
+    ax_group = fig.add_subplot(grid[0, 0])
+    ax_heat = fig.add_subplot(grid[0, 1])
+    ax_cbar = fig.add_subplot(grid[0, 2])
+
+    ax_group.imshow(
+        group_codes.reshape(-1, 1),
+        aspect="auto",
+        cmap=ListedColormap([palette[group] for group in groups]),
+        interpolation="nearest",
+    )
+    ax_group.set_xticks([])
+    ax_group.set_yticks([])
+    ax_group.set_ylabel("Group", fontsize=9)
+
+    sns.heatmap(
+        plot_df,
+        cmap="RdBu_r",
+        ax=ax_heat,
+        cbar_ax=ax_cbar,
+        xticklabels=plot_df.shape[1] <= 50,
+        yticklabels=plot_df.shape[0] <= 50,
+        linewidths=0,
+    )
+    ax_heat.set_title("Grouped Heatmap (Top ANOVA-ranked Features)", fontsize=12)
+    ax_heat.set_xlabel("Features")
+    ax_heat.set_ylabel("Samples")
+
+    boundaries: list[int] = []
+    previous = None
+    for index, group in enumerate(ordered_labels.astype(str).tolist()):
+        if previous is not None and group != previous:
+            boundaries.append(index)
+        previous = group
+    for boundary in boundaries:
+        ax_group.axhline(boundary - 0.5, color="white", linewidth=1.2)
+        ax_heat.axhline(boundary, color="black", linewidth=0.7)
+
+    legend_handles = [
+        Patch(facecolor=palette[group], edgecolor="none", label=group) for group in groups
+    ]
+    ax_heat.legend(
+        handles=legend_handles,
+        loc="upper left",
+        bbox_to_anchor=(1.02, 1.0),
+        fontsize=8,
+        title="Group",
+    )
+    fig.tight_layout()
+    return fig
 
 
 def plot_heatmap(


### PR DESCRIPTION
## Summary
- Add formal DNP Step4 feature-metadata consumption: strict `is_Presence_Absence_Marker` routing, preserved audit metadata, and sample-column detection that excludes Step4 metadata fields.
- Add marker-aware imputation behavior so presence/absence marker features use min positive / 5 while non-marker features use the configured imputation method.
- Add optional ComBat batch correction with `SampleInfo.Batch`, covariate modes, CLI/GUI validation, and confounding/overlap warnings.
- Improve publication/report outputs with grouped heatmap, PNG-only `00_Review_Pack`, `Evidence_Tier` in summary exports, and color-coded tier cells in the summary workbook.
- Update README and preset documentation to match the current CLI/GUI workflow, config semantics, report layout, and validation expectations.

## Validation
- `python -m pytest tests\test_sample_interface.py tests\test_run_from_config_input_formats.py -q`
- `python -m pytest tests\test_core.py -k 'marker or imputation or presence or absence or qc_rsd' -q`
- `python -m pytest tests\test_gui_runtime_feature_metadata.py -q`
- `python -m pytest tests\test_run_from_config_input_formats.py tests\test_grouped_heatmap.py tests\test_publication_batch_report_smoke.py -q`
- `python -m pytest tests\test_publication_export_v2.py::TestHeatmapLabelThreshold -q`
- `.\tools\ci\run_pytest_targets.ps1 -GroupNames @("pr-gui-shell")`
- `python -m py_compile core\feature_metadata.py core\sample_interface.py gui\data_import_tab.py scripts\run_from_config.py scripts\run_from_config.py visualization\heatmap.py visualization\__init__.py`
- Real-file smoke validation on `Step3_Normalized_SpecNorm_PQN.xlsx`: expected `85 x 280`, marker `127 True / 153 False`, reason columns excluded from sample index, ratio metadata preserved.
- Real-file CLI validation for Review Pack, grouped heatmap, Evidence_Tier, and output suffix semantics.